### PR TITLE
first down mountain: reset all players to starting line each new game

### DIFF
--- a/src/components/lessons/first-down-to-mountain/ManyGamesApp.vue
+++ b/src/components/lessons/first-down-to-mountain/ManyGamesApp.vue
@@ -92,7 +92,10 @@ export default {
         winnerIndex = this.checkWinnerIndex();
       }
       this.game[winnerIndex].wins++;
-      this.game[winnerIndex].currentSpace = 0;
+      // reset all players to the start line
+      for (let i = 0; i < this.game.length; i++) {
+        this.game[i].currentSpace = 0;
+      }
       this.tried++;
       if (this.tried >= this.trialNumber) {
         this.status = 2;


### PR DESCRIPTION
Previously only the winner was reset at the end of each game for multiple trials, skewing the results towards a normal bell-curve-like distribution. The corrected version looks more like a "U" distribution.