### PR TITLE
Readability changes

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -97,7 +97,7 @@ export default {
     sortedLessons: function() {
       // Sort lessons on alphabetical order
       const sorted = this.lessons.slice().sort(function(l1, l2) {
-        if (l1.name <= l2.name) return -1;
+        if (l1.name.toLowerCase() <= l2.name.toLowerCase()) return -1;
         else return 1;
       });
       return sorted;

--- a/src/components/common/EnterTrialsNumber.vue
+++ b/src/components/common/EnterTrialsNumber.vue
@@ -2,7 +2,7 @@
 	<div>
 		<div class="app--enter-number form-group row mt-5">
 			<label for="trial-numbers" class="col-form-label col-sm-6">
-				Enter the number of trials (1 to 10,000):
+				Enter the number of trials (1 to {{ legify(10000) }}):
 			</label>
 			<div class="col-sm-6">
 				<input type="number" class="form-control" v-model="trialNumber" required>
@@ -19,6 +19,7 @@
 </template>
 
 <script>
+	import { legify } from "./utils.js";
 	export default {
 		data: function() {
 			return {
@@ -37,6 +38,7 @@
 			}
 		},
 		methods: {
+			legify,
 			handleAcceptTrialNumber() {
 				this.$emit('acceptTrialNumber', this.trialNumber);
 			}

--- a/src/components/common/utils.js
+++ b/src/components/common/utils.js
@@ -57,3 +57,58 @@ export const separateNumber = number => {
   }
   return arr.join(",");
 };
+
+
+/**
+ * Convert a number into a clean 'legible' format for students
+ * that matches modern maths textbooks.
+ * Integers separated by 'thin spaces' every 3 digits right to left
+ * Decimals separated by 'thin spaces' every 3 digits left to right
+ * Takes optional parameter for fixing number of decimal places
+ * to stop jitter in trials.
+ * e.g. 1234.56789, 4 => 1 234.567 8
+ * (thin spaces appear to be regular in monospace fonts)
+ * Performance note:
+ * Tested with console.time() and runs surprisingly fast.
+ * Function can run roughly 300 times / ms so shouldn't affect
+ * frames in trials that update every 17 ms
+ * @param {Number} number
+ * @param {Number) fixedDec
+ * @return {String}
+ */
+export function legify(number, fixedDec = -1) {
+	let spacer = '\u2009'; // thin space
+  let numberString = fixedDec < 0 ? number.toString() : Number(number).toFixed(fixedDec);
+	// break into integer and decimal parts
+  let decIndex = numberString.indexOf('.');
+  let intString;
+  let decString;
+  if (decIndex === -1) {
+    intString = numberString;
+  }
+  else if (decIndex > 0) {
+    intString = numberString.slice(0, decIndex);
+    decString = numberString.slice(decIndex + 1, numberString.length);
+  }
+  else { // '.' as zeroeth char
+    intString = '0';
+    decString = numberString.slice(1, numberString.length);
+  }
+
+  // insert spaces for integer part
+  let newIntString = '';
+  for (let i = 0; i < intString.length; i++) {
+    let lenToEnd = intString.length - (i + 1);
+    newIntString = lenToEnd % 3 === 0 && lenToEnd !== 0 ? newIntString + intString[i] + spacer : newIntString + intString[i];
+  }
+
+	// insert spaces for decimal part
+  let newDecString = '';
+  if (decIndex > -1) {
+    for (let i = 0; i < decString.length; i++) {
+      newDecString = (i + 1) % 3 === 0 && (i + 1) !== decString.length ? newDecString + decString[i] + spacer : newDecString + decString[i];
+    }
+  }
+
+  return decIndex === -1 ? newIntString : newIntString + '.' + newDecString;
+}

--- a/src/components/common/utils.js
+++ b/src/components/common/utils.js
@@ -77,6 +77,7 @@ export const separateNumber = number => {
  * @return {String}
  */
 export function legify(number, fixedDec = -1) {
+  if (!number && number !== 0) {return ""} // handle undefined
 	let spacer = '\u2009'; // thin space
   let numberString = fixedDec < 0 ? number.toString() : Number(number).toFixed(fixedDec);
 	// break into integer and decimal parts

--- a/src/components/common/utils.js
+++ b/src/components/common/utils.js
@@ -73,7 +73,7 @@ export const separateNumber = number => {
  * Function can run roughly 300 times / ms so shouldn't affect
  * frames in trials that update every 17 ms
  * @param {Number} number
- * @param {Number) fixedDec
+ * @param {Number} [fixedDec]
  * @return {String}
  */
 export function legify(number, fixedDec = -1) {

--- a/src/components/lessons/2-litre-ballon/DisplayData.vue
+++ b/src/components/lessons/2-litre-ballon/DisplayData.vue
@@ -31,7 +31,7 @@
             <tbody v-if="isSet">
               <tr v-for="(item, index) in dataArray" :key="index">
                 <td class="text-center">{{ item.getValue(unit) }}</td>
-                <td class="text-center">{{ item.getValue(unit2) }}</td>
+                <td class="text-center">{{ legify(item.getValue(unit2), 6) }}</td>
               </tr>
             </tbody>
           </table>
@@ -106,6 +106,7 @@
 import Chart from "chart.js";
 import Ballon from "./Ballon";
 import DemoAutoOption from "../../common/DemoAutoOption.vue";
+import { legify } from "../../common/utils.js";
 
 export default {
   components: {
@@ -254,6 +255,7 @@ export default {
     }
   },
   methods: {
+    legify,
     /** Validate input and set data if validation is passed */
     handleStart() {
       if ((!this.min || !this.max) && (this.min !== 0)) { // handle case where Javascript treats 0 as 'falsy'

--- a/src/components/lessons/addo/ManyGamesApp.vue
+++ b/src/components/lessons/addo/ManyGamesApp.vue
@@ -177,7 +177,7 @@ export default {
         checkCanAddo(this.selectedStrategy.strategyData[1]) ||
         checkCanAddo(this.selectedStrategy.strategyData[2])
       ) {
-        console.log(checkCanAddo(this.selectedStrategy.strategyData[0]));
+        //console.log(checkCanAddo(this.selectedStrategy.strategyData[0]));
         this.gameNumber = 0;
         this.gameStatus = 1;
         this.winStats = [0, 0, 0];

--- a/src/components/lessons/addo/ManyGamesStat.vue
+++ b/src/components/lessons/addo/ManyGamesStat.vue
@@ -16,14 +16,14 @@
                 ? 'visible'
                 : 'hidden'
             }"
-      >Game {{gameNumber}} of {{trialNumber}}</h5>
+      >Game {{ legify(gameNumber) }} of {{ legify(trialNumber) }}</h5>
     </div>
     <div>
       <h6 class="ml-2">Wins</h6>
       <div class="flex-grow-1 d-flex flex-row justify-content-around">
-        <div class="border flex-fill mx-4 my-1 text-right pr-2">{{ winStats[0] }}</div>
-        <div class="border flex-fill mx-4 my-1 text-right pr-2">{{ winStats[1] }}</div>
-        <div class="border flex-fill mx-4 my-1 text-right pr-2">{{ winStats[2] }}</div>
+        <div class="border flex-fill mx-4 my-1 text-right pr-2">{{ legify(winStats[0]) }}</div>
+        <div class="border flex-fill mx-4 my-1 text-right pr-2">{{ legify(winStats[1]) }}</div>
+        <div class="border flex-fill mx-4 my-1 text-right pr-2">{{ legify(winStats[2]) }}</div>
       </div>
       <div class="flex-grow-1 d-flex flex-row justify-content-around">
         <div class="border flex-grow-1 mx-4 my-1 text-right pr-2">{{ winPercent0 }}</div>
@@ -35,7 +35,11 @@
 </template>
 
 <script>
+import { legify } from "../../common/utils.js";
 export default {
+  methods: {
+    legify
+  },
   props: [
     "totalCardNumbers",
     "gameNumber",
@@ -48,31 +52,25 @@ export default {
       if (!this.gameNumber) {
         return 0;
       }
-      return String((this.totalCardNumbers / this.gameNumber).toFixed(2));
+      return legify( (this.totalCardNumbers / this.gameNumber), 2 );
     },
     winPercent0() {
       if (!this.gameNumber) {
         return 0;
       }
-      return (
-        String(((this.winStats[0] / this.gameNumber) * 100).toFixed(2)) + "%"
-      );
+      return legify( (this.winStats[0] / this.gameNumber) * 100, 2 ) + "%";
     },
     winPercent1() {
       if (!this.gameNumber) {
         return 0;
       }
-      return (
-        String(((this.winStats[1] / this.gameNumber) * 100).toFixed(2)) + "%"
-      );
+      return legify( (this.winStats[1] / this.gameNumber) * 100, 2 ) + "%";
     },
     winPercent2() {
       if (!this.gameNumber) {
         return 0;
       }
-      return (
-        String(((this.winStats[2] / this.gameNumber) * 100).toFixed(2)) + "%"
-      );
+      return legify( (this.winStats[2] / this.gameNumber) * 100, 2 ) + "%";
     }
   }
 };

--- a/src/components/lessons/beetle-game/EnterTrialsNumber.vue
+++ b/src/components/lessons/beetle-game/EnterTrialsNumber.vue
@@ -2,7 +2,7 @@
     <div>
         <div class="app--enter-number form-group row mt-5">
             <label for="trial-numbers" class="col-form-label col-sm-6">
-                Enter the number of trials (100 to 10,000):
+                Enter the number of trials (100 to 10 000):
             </label>
             <div class="col-sm-6">
                 <input type="number" class="form-control" v-model="trialNum" required>

--- a/src/components/lessons/beetle-game/MakeManyBeetles.vue
+++ b/src/components/lessons/beetle-game/MakeManyBeetles.vue
@@ -52,7 +52,7 @@
               colspan="2"
               style="text-align: center; color: #001cc6; font-weight: bold"
             >
-              {{ trialNum }} games
+              {{ legify(trialNum) }} games
             </td>
           </tr>
           <tr>
@@ -60,7 +60,7 @@
               colspan="2"
               style="text-align: center; color: #001cc6; font-weight: bold"
             >
-              Game {{ count }}
+              Game {{ legify(count) }}
             </td>
           </tr>
           <tr>
@@ -211,6 +211,7 @@
 
 <script>
 import DemoAutoOption from "./DemoAutoOption.vue";
+import { legify } from "../../common/utils.js";
 
 export default {
   props: ["trialNum"],
@@ -281,6 +282,7 @@ export default {
   },
   mounted: function() {},
   methods: {
+    legify,
     generateRandom(num) {
       //from 0 - num
       return Math.round(Math.random() * (num - 1)) + 1;

--- a/src/components/lessons/biggest-volume/App.vue
+++ b/src/components/lessons/biggest-volume/App.vue
@@ -8,18 +8,18 @@
 		</div>
 		<div class="container-fluid" v-else>
 			<transition appear appear-class="lesson-appear" appear-active-class="lesson-appear-active">
-				<app-top-nav @backToMenu="selectedOption = $event">Biggest Volume</app-top-nav> 
-			</transition> 
-				
+				<app-top-nav @backToMenu="selectedOption = $event">Biggest Volume</app-top-nav>
+			</transition>
+
 			<transition appear appear-class="lesson-appear" appear-active-class="lesson-appear-active">
 				<app-cut-out-squares v-if="selectedOption === 1"></app-cut-out-squares>
-			</transition> 
+			</transition>
 			<transition appear appear-class="lesson-appear" appear-active-class="lesson-appear-active">
 				<app-calculate-and-display v-if="selectedOption === 2"></app-calculate-and-display>
-			</transition> 
-		</div> 
+			</transition>
+		</div>
     <!-- <transition appear appear-class="options-appear" appear-active-class="options-appear-active">
-			<app-bottom-nav></app-bottom-nav> 
+			<app-bottom-nav></app-bottom-nav>
 		</transition> -->
 	</div>
 </template>
@@ -46,7 +46,7 @@ export default {
 		return {
 			options: [
 				{id: 1, title: 'Cut out squares'},
-				{id: 2, title: 'Calculate and display a range of up to 11 volumes'}
+				{id: 2, title: 'Calculate and display a range of up to eleven volumes'}
 			],
 			selectedOption: -1
 		}

--- a/src/components/lessons/biggest-volume/CalculateAndDisplay.vue
+++ b/src/components/lessons/biggest-volume/CalculateAndDisplay.vue
@@ -4,7 +4,7 @@
       <div class="row">
         <div class="col-12">
           <div>
-            <h3 class="lesson-subheading">Calculate and display a range of up to 11 volumes</h3>
+            <h3 class="lesson-subheading">Calculate and display a range of up to eleven volumes</h3>
             <hr class="subheading-separator">
             <h4 class="text text-center mb-4">Paper size</h4>
             <div class="row">

--- a/src/components/lessons/birth-month-paradox/BirthdayParadox.vue
+++ b/src/components/lessons/birth-month-paradox/BirthdayParadox.vue
@@ -6,7 +6,7 @@
         <div class="container mt-4 mb-5" v-if="!isSet" style="width: 60%">
             <div class="form-group row">
                 <label class="col-sm-6">
-                    Enter the number of trials (1 to 10000)
+                    Enter the number of trials (1 to {{ legify(10000) }})
                 </label>
                 <div class="col-sm-6">
                     <input type="number"
@@ -54,7 +54,7 @@
                     <tr>
                         <td style="width: 40%; text-align: left">Trial</td>
                         <td><input style="text-align: right; width:100%" class="inputNumber" disabled type="text" id="inputTrial" v-model="trials" /></td>
-                        <td style="text-align: right">{{displayTrial}} trails</td>
+                        <td style="text-align: right">{{legify(displayTrial)}} trials</td>
                     </tr>
                     <tr>
                         <td style="width: 40%; text-align: left">Matched</td>
@@ -99,6 +99,7 @@
     import {
         isBirthDayMatch
     } from "./utils";
+    import { legify } from "../../common/utils.js";
 
     export default {
         components: {
@@ -170,6 +171,7 @@
         },
         mounted: function() {},
         methods: {
+          legify,
             okBtn() {
                 this.isChecked1 = true;
                 this.isChecked2 = true;

--- a/src/components/lessons/birth-month-paradox/ManyTrialsFast.vue
+++ b/src/components/lessons/birth-month-paradox/ManyTrialsFast.vue
@@ -6,7 +6,7 @@
         <div class="container mt-4 mb-5" v-if="!isSet" style="width: 60%">
             <div class="form-group row">
                 <label class="col-sm-6">
-                    Enter the number of trials (1 to 10000)
+                    Enter the number of trials (1 to {{ legify(10000) }})
                 </label>
                 <div class="col-sm-6">
                     <input type="number"
@@ -54,7 +54,7 @@
                     <tr>
                         <td style="width: 40%; text-align: left">Trial</td>
                         <td><input style="text-align: right; width:100%" class="inputNumber" disabled type="text" id="inputTrial" v-model="trials" /></td>
-                        <td style="text-align: right">{{displayTrial}} trails</td>
+                        <td style="text-align: right">{{ legify(displayTrial) }} trails</td>
                     </tr>
                     <tr>
                         <td style="width: 40%; text-align: left">Matched</td>
@@ -99,6 +99,7 @@
     import {
         isMatch
     } from "./utils";
+    import { legify } from "../../common/utils.js";
 
     export default {
         components: {
@@ -170,6 +171,8 @@
         },
         mounted: function() {},
         methods: {
+            legify,
+
             okBtn() {
                 this.isChecked1 = true;
                 this.isChecked2 = true;

--- a/src/components/lessons/birth-month-paradox/VaryTheGroupSizeAndTheNumberOfTrials.vue
+++ b/src/components/lessons/birth-month-paradox/VaryTheGroupSizeAndTheNumberOfTrials.vue
@@ -72,15 +72,15 @@
                 <div id="controller" style="margin-left: 20%; margin-top: 20px;">
                     <div>
                         <button class="btn btn-outline-success" v-if="!finished && demoAutoOption === '0'" @click="executeManually">
-                            {{ isStart ? "Tap here for next game" : "Tap here for first game" }}
+                            {{ isStart ? "Next game" : "First game" }}
                         </button>
                         <button class="btn btn-outline-success" v-if="!finished && demoAutoOption === '1'" @click="startGameAuto">
                             {{
                             !isAutoStart
-                            ? "Tap here to begin"
+                            ? "Start"
                             : timer
-                            ? "Tap here to pause"
-                            : "Tap here to resume"
+                            ? "Pause"
+                            : "Resume"
                             }}
                         </button>
                         <button class="btn btn-outline-dark" v-if="finished" @click="resetII()">

--- a/src/components/lessons/bobs-button/InputPanel.vue
+++ b/src/components/lessons/bobs-button/InputPanel.vue
@@ -8,7 +8,7 @@
           type="number"
           class="form-control"
           v-model.number="groupSizeA"
-          @focus="message='Enter the group size (2-10,000)'"
+          @focus="message='Enter the group size (2 to ' + legify(10000) + ')'"
           min="1"
           max="10000"
           step="1"
@@ -20,7 +20,7 @@
           type="number"
           class="form-control"
           v-model.number="leftOverA"
-          @focus="message='Enter the left over number (0-1,000)'"
+          @focus="message='Enter the group size (1 to ' + legify(1000) + ')'"
           min="0"
           max="1000"
           step="1"
@@ -35,7 +35,7 @@
           type="number"
           class="form-control"
           v-model.number="groupSizeB"
-          @focus="message='Enter the group size (2-10,000)'"
+          @focus="message='Enter the group size (2 to ' + legify(10000) + ')'"
           min="1"
           max="10000"
           step="1"
@@ -47,7 +47,7 @@
           type="number"
           class="form-control"
           v-model.number="leftOverB"
-          @focus="message='Enter the left over number (0-1,000)'"
+          @focus="message='Enter the group size (1 to ' + legify(1000) + ')'"
           min="0"
           max="1000"
           step="1"
@@ -93,6 +93,8 @@
   </div>
 </template>
 <script>
+import { legify } from "../../common/utils.js";
+
 export default {
   data: function() {
     return {
@@ -151,6 +153,7 @@ export default {
     }
   },
   methods: {
+    legify,
     handleOK() {
       this.$emit("setGroupsRule", {
         groupSizeA: this.groupSizeA,

--- a/src/components/lessons/cat-and-mouse/PlayManyGamesApp.vue
+++ b/src/components/lessons/cat-and-mouse/PlayManyGamesApp.vue
@@ -25,7 +25,7 @@
           {{ game.ruleLeft.join('') === '135' ?
           "O for Odd, E for Even numbers" :
           `Move left for ${game.ruleLeft.join()}`
-          }} - {{ trialNumber }} trials
+          }} - {{ legify(trialNumber) }} trials
         </span>
         <span v-else></span>
       </h4>
@@ -33,25 +33,25 @@
         <tr>
           <th>Mouse</th>
           <td>
-            <span v-if="total > 0">{{ mouseWins }}</span>
+            <span v-if="total > 0">{{ legify(mouseWins) }}</span>
           </td>
           <td>
-            <span v-if="total > 0">{{ mouseWinsPercent }}%</span>
+            <span v-if="total > 0">{{ mouseWinsPercent.toFixed(2) }}%</span>
           </td>
         </tr>
         <tr>
           <th>Cat</th>
           <td>
-            <span v-if="total > 0">{{ catWins }}</span>
+            <span v-if="total > 0">{{ legify(catWins) }}</span>
           </td>
           <td>
-            <span v-if="total > 0">{{ catWinsPercent }}%</span>
+            <span v-if="total > 0">{{ catWinsPercent.toFixed(2) }}%</span>
           </td>
         </tr>
         <tr>
           <th>Total</th>
           <td>
-            <span v-if="total > 0">{{ total }}</span>
+            <span v-if="total > 0">{{ legify(total) }}</span>
           </td>
           <td>
             <span v-if="isStart && game.ruleType==='decimal'">{{ randomNumber }}</span>
@@ -97,7 +97,7 @@ import DemoAutoOption from "../../common/DemoAutoOption.vue";
 import Gameboard from "./Gameboard.vue";
 import mouse from "@/assets/cat-and-mouse/mouse.jpg";
 import Game from "./game/Game";
-import { calculateTimerInterval } from "../../common/utils";
+import { calculateTimerInterval, legify } from "../../common/utils";
 
 export default {
   components: {
@@ -153,6 +153,7 @@ export default {
     }
   },
   methods: {
+    legify,
     initGame() {
       this.isStart = false;
       this.isFinish = false;

--- a/src/components/lessons/chip-cookies/Trials100.vue
+++ b/src/components/lessons/chip-cookies/Trials100.vue
@@ -51,7 +51,7 @@
       </div>
       <div class="text-center" v-if="gameStatus===1">
         <div class="alert alert-danger">Finished 100 batches</div>
-        <button class="btn btn-outline-dark" @click="handleReset">Tap here to reset</button>
+        <button class="btn btn-outline-dark" @click="handleReset">Reset</button>
       </div>
     </div>
   </div>

--- a/src/components/lessons/counter-escape/AllArrangements.vue
+++ b/src/components/lessons/counter-escape/AllArrangements.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="container">
+  <div class="container mt-3">
+    <h3 class="lesson-subheading">All possible arrangements</h3>
+    <hr class="subheading-separator">
     <app-all-arrangements-app
       v-if="trialNumber && gameRule.boxes == 3"
       :numberOfGames="trialNumber"

--- a/src/components/lessons/counter-escape/AllArrangementsApp.vue
+++ b/src/components/lessons/counter-escape/AllArrangementsApp.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mt-3 mb-5">
-    <h3 class="text-success text-center">{{ numberOfGames }} trials for each arrangement</h3>
+    <h5 class="text-success text-center">{{ numberOfGames }} trials for each arrangement</h5>
     <div class="app--arrangement-table">
       <table class="table table-bordered" style="table-layout: fixed">
         <thead>
@@ -15,7 +15,7 @@
             <td
               class="text-center"
               :class="{ 'smallest-count': smallestAverageCounts === arrangementAverageCounts[index] }"
-            >{{ arrangementAverageCounts[index] ? Number(arrangementAverageCounts[index].toFixed(2)) : '' }}</td>
+            >{{ arrangementAverageCounts[index] ? arrangementAverageCounts[index].toFixed(2) : '' }}</td>
           </tr>
         </tbody>
       </table>

--- a/src/components/lessons/counter-escape/PlayAGame.vue
+++ b/src/components/lessons/counter-escape/PlayAGame.vue
@@ -1,5 +1,9 @@
-<template> 
-	<app-play-game :gameRule="gameRule" :numberOfGames="1"></app-play-game>
+<template>
+	<div class="mt-3">
+		<h3 class="lesson-subheading">Which arrangement is the best?</h3>
+		<hr class="subheading-separator">
+		<app-play-game :gameRule="gameRule" :numberOfGames="1"></app-play-game>
+	</div>
 </template>
 
 <script>
@@ -12,5 +16,5 @@ export default {
 }
 </script>
 
-<style scoped> 
+<style scoped>
 </style>

--- a/src/components/lessons/counter-escape/PlayGame.vue
+++ b/src/components/lessons/counter-escape/PlayGame.vue
@@ -1,7 +1,6 @@
 <template>
 	<div class="container mt-4 mb-5">
-		<h3 class="text-success text-center">
-			Which arrangement is the best?<br>
+		<h3 class="text-center">
 			<span v-if="numberOfGames != 1" class="small">{{ numberOfGames }} trials</span>
 		</h3>
 		<p class="text-dark text-center">

--- a/src/components/lessons/counter-escape/PlayManyGames.vue
+++ b/src/components/lessons/counter-escape/PlayManyGames.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="container">
+  <div class="container mt-3">
+    <h3 class="lesson-subheading">Play many games</h3>
+    <hr class="subheading-separator">
     <app-play-game v-if="trialNumber" :numberOfGames="trialNumber" :gameRule="gameRule"></app-play-game>
     <app-enter-trials-number v-else @acceptTrialNumber="trialNumber=$event"></app-enter-trials-number>
   </div>

--- a/src/components/lessons/crazy-animals/HowManyTrials.vue
+++ b/src/components/lessons/crazy-animals/HowManyTrials.vue
@@ -1,5 +1,7 @@
 <template>
-  <div>
+  <div class="container mt-3">
+    <h3 class="lesson-subheading">How many trials to make your favourite?</h3>
+    <hr class="subheading-separator">
     <app-how-many-trials-app
       v-if="trialNumber&&selectedAnimalData"
       :trialNumber="trialNumber"

--- a/src/components/lessons/crazy-animals/HowManyTrialsApp.vue
+++ b/src/components/lessons/crazy-animals/HowManyTrialsApp.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="container mt-4 mb-5">
-    <h3 class="lesson-subheading">How many trials to make our favourite animal?</h3>
-    <hr class="subheading-separator">
+  <div class="container">
     <div class="row">
       <div class="col-12 col-sm-6">
         <app-animal-picture :animalDrawn="animalDrawn"></app-animal-picture>
@@ -12,12 +10,12 @@
         <div class="app--stat">
           <table class="table" style="table-layout:fixed;">
             <tr class="text-center">
-              <td class="table-danger">{{ trialNumber }}</td>
+              <td class="table-danger">{{ legify(trialNumber) }}</td>
               <td class="table-primary">trials</td>
             </tr>
             <tr class="text-center">
               <td class="table-danger">
-                <span v-if="isStart">{{ count }}</span>
+                <span v-if="isStart">{{ legify(count) }}</span>
               </td>
               <td class="table-primary">count</td>
             </tr>
@@ -29,7 +27,7 @@
             </tr>
             <tr class="text-center">
               <td class="table-danger">
-                <span v-if="isStart">{{ matched ? soFar : '--' }}</span>
+                <span v-if="isStart">{{ matched ? soFar.toFixed(2) : '--' }}</span>
               </td>
               <td class="table-primary">{{demoAutoOption == '0' ? "so far" : "average"}}</td>
             </tr>
@@ -81,7 +79,7 @@ import {
   getAnimalsPart,
   throwDiceOnce
 } from "./utils";
-import { calculateTimerInterval } from "../../common/utils";
+import { calculateTimerInterval, legify } from "../../common/utils";
 
 import duckBody from "@/assets/duck-body.jpg";
 import duckHead from "@/assets/duck-head.jpg";
@@ -159,6 +157,7 @@ export default {
     }
   },
   methods: {
+    legify,
     getAnimalDrawn() {
       const combinationArr = this.selectedAnimalData.selectedAnimal.split(",");
       const head = {

--- a/src/components/lessons/crazy-animals/MostLikelyAnimal.vue
+++ b/src/components/lessons/crazy-animals/MostLikelyAnimal.vue
@@ -1,5 +1,7 @@
 <template>
-  <div>
+  <div class="container mt-3">
+    <h3 class="lesson-subheading">Which animal is most likely?</h3>
+    <hr class="subheading-separator">
     <app-most-likely-animal-app v-if="trialNumber" :trialNumber="trialNumber"></app-most-likely-animal-app>
     <app-enter-trials-number v-else @acceptTrialNumber="trialNumber=$event"></app-enter-trials-number>
   </div>

--- a/src/components/lessons/crazy-animals/MostLikelyAnimalApp.vue
+++ b/src/components/lessons/crazy-animals/MostLikelyAnimalApp.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="app--container container mt-4 mb-5">
-    <h3 class="lesson-subheading">Which animal is most likely?</h3>
-    <hr class="subheading-separator">
+  <div class="app--container container">
     <div class="form-check form-check-inline d-flex justify-content-center">
       <input
         class="form-check-input"
@@ -27,12 +25,12 @@
     <div class="app--animals-table mt-3">
       <h5
         class="text-success text-center"
-      >{{ trialNumber }} trials in total - {{ triedNumber }} tried</h5>
+      >{{ legify(trialNumber) }} trials in total - {{ legify(triedNumber) }} tried</h5>
       <div class="app--animal-list">
         <div class="app--animal-item" v-for="(item, index) in allAnimals" :key="index">
           <h4>
             {{ item.animal }}
-            <span class="badge badge-danger">{{ item.count }}</span>
+            <span class="badge badge-danger">{{ legify(item.count) }}</span>
           </h4>
         </div>
       </div>
@@ -68,7 +66,7 @@
 
 <script>
 import DemoAutoOption from "./DemoAutoOption.vue";
-import { calculateTimerInterval } from "../../common/utils";
+import { calculateTimerInterval, legify } from "../../common/utils";
 import {
   throwDiceOnce,
   generateAnimalsParts,
@@ -122,6 +120,7 @@ export default {
     }
   },
   methods: {
+    legify,
     generateAnimals() {
       // Generate all animals with different combinations
       this.allAnimals = [];

--- a/src/components/lessons/crazy-animals/WholeAndPart.vue
+++ b/src/components/lessons/crazy-animals/WholeAndPart.vue
@@ -1,5 +1,7 @@
 <template>
-  <div>
+  <div class="container mt-3">
+    <h3 class="lesson-subheading">Whole and part animals</h3>
+    <hr class="subheading-separator">
     <app-whole-and-part-app v-if="trialNumber" :trialNumber="trialNumber"></app-whole-and-part-app>
     <app-enter-trials-number v-else @acceptTrialNumber="trialNumber=$event"></app-enter-trials-number>
   </div>

--- a/src/components/lessons/crazy-animals/WholeAndPartApp.vue
+++ b/src/components/lessons/crazy-animals/WholeAndPartApp.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="container mt-4 mb-5">
-    <h3 class="lesson-subheading">Whole and part animals</h3>
-    <hr class="subheading-separator">
+  <div class="container">
     <div class="form-check form-check-inline d-flex justify-content-center">
       <input
         class="form-check-input"
@@ -42,8 +40,8 @@
           <td>{{ item[1][0] }}</td>
         </tr>
       </table>
-      <h5 class="text-center">{{ trialNumber }} with {{ numberOfAnimals }} animals</h5>
-      <h5 class="text-center">{{ count }} so far</h5>
+      <h5 class="text-center">{{ legify(trialNumber) }} with {{ numberOfAnimals }} animals</h5>
+      <h5 class="text-center">{{ legify(count) }} so far</h5>
     </div>
 
     <div class="app--action text-center">
@@ -76,7 +74,7 @@
 <script>
 import DemoAutoOption from "./DemoAutoOption.vue";
 import { throwDiceOnce, getAnimalsPart } from "./utils";
-import { calculateTimerInterval } from "../../common/utils";
+import { calculateTimerInterval, legify } from "../../common/utils";
 export default {
   components: {
     appDemoAutoOption: DemoAutoOption
@@ -120,6 +118,7 @@ export default {
     }
   },
   methods: {
+    legify, 
     handleNextAnimal() {
       if (!this.isStart) this.isStart = true;
       let head = getAnimalsPart(throwDiceOnce(), this.numberOfAnimals);

--- a/src/components/lessons/cylinder-volumes/FindMaximum.vue
+++ b/src/components/lessons/cylinder-volumes/FindMaximum.vue
@@ -15,19 +15,19 @@
                 Area (cm
                 <sup>2</sup>)
               </th>
-              <td>{{ area }}</td>
+              <td>{{ legify(area) }}</td>
             </tr>
             <tr>
               <th>Paper height (cm)</th>
-              <td>{{ height }}</td>
+              <td>{{ legify(height) }}</td>
             </tr>
             <tr>
               <th>Paper width (cm)</th>
-              <td>{{ width }}</td>
+              <td>{{ legify(width) }}</td>
             </tr>
             <tr>
               <th>Current height (cm)</th>
-              <td>{{ currentHeight }}</td>
+              <td>{{ legify(Math.round(currentHeight * 100) / 100) }}</td>
             </tr>
             <tr>
               <th></th>
@@ -88,9 +88,9 @@
               :key="index"
               :class="{'table-primary': index===maxIndex }"
             >
-              <td>{{ data.height }}</td>
-              <td>{{ data.radius }}</td>
-              <td>{{ data.volume }}</td>
+              <td>{{ legify(Math.round(data.height * 100) / 100) }}</td>
+              <td>{{ legify(data.radius, 2) }}</td>
+              <td>{{ legify(data.volume, 2) }}</td>
             </tr>
           </table>
         </div>
@@ -102,6 +102,7 @@
 <script>
 import InputPanel from "./InputPanel.vue";
 import { calculateRadius, calculateArea, calculateVolume } from "./utils";
+import { legify } from "../../common/utils.js";
 
 export default {
   components: {
@@ -124,8 +125,8 @@ export default {
         const [height, radius, volume] = this.calculate(this.currentHeight);
         this.resultArr.push({
           height,
-          radius: Number(radius.toFixed(6)),
-          volume: Number(volume.toFixed(6))
+          radius: radius,
+          volume: volume
         });
       } else {
         this.currentHeight = 0;
@@ -161,6 +162,7 @@ export default {
     }
   },
   methods: {
+    legify,
     handleOK() {
       if (!this.isValidInput) {
         return;
@@ -172,16 +174,14 @@ export default {
         const [height, radius, volume] = this.calculate(this.currentHeight);
         this.resultArr.push({
           height: height,
-          radius: Number(radius.toFixed(2)),
-          volume: Number(volume.toFixed(2))
+          radius: radius,
+          volume: volume
         });
         count++;
         if (count >= 11) {
           break;
         }
-        let nextCurrentHeight = Number(
-          (this.currentHeight + this.incDec * this.increment).toFixed(10)
-        );
+        let nextCurrentHeight = (this.currentHeight + this.incDec * this.increment);
         if (nextCurrentHeight <= 0) {
           break;
         }

--- a/src/components/lessons/cylinder-volumes/TallSquatCylinders.vue
+++ b/src/components/lessons/cylinder-volumes/TallSquatCylinders.vue
@@ -17,18 +17,18 @@
             <tbody>
               <tr>
                 <th>Height (cm)</th>
-                <td>{{ leftHeight }}</td>
-                <td>{{ rightHeight }}</td>
+                <td>{{ legify(leftHeight) }}</td>
+                <td>{{ legify(rightHeight) }}</td>
               </tr>
               <tr>
                 <th>Radius (cm)</th>
-                <td>{{ leftRadius }}</td>
-                <td>{{ rightRadius }}</td>
+                <td>{{ legify(leftRadius, 6) }}</td>
+                <td>{{ legify(rightRadius, 6) }}</td>
               </tr>
               <tr>
                 <th>Volume (L)</th>
-                <td>{{ currentLeftVol }}</td>
-                <td>{{ currentRightVol }}</td>
+                <td>{{ legify(currentLeftVol, 4) }}</td>
+                <td>{{ legify(currentRightVol, 4) }}</td>
               </tr>
             </tbody>
           </table>
@@ -74,6 +74,7 @@
 <script>
 import InputPanel from "./InputPanel.vue";
 import { calculateRadius, calculateArea, calculateVolume } from "./utils";
+import { legify } from "../../common/utils.js";
 export default {
   components: {
     appInputPanel: InputPanel
@@ -130,16 +131,16 @@ export default {
     },
     currentLeftVol() {
       let currentVol = Number(
-        (((this.leftIncrease / this.rate) * this.leftArea) / 1000).toFixed(4)
+        (((this.leftIncrease / this.rate) * this.leftArea) / 1000)
       );
-      let maxLeftVol = Number((this.leftVol / 1000).toFixed(4));
+      let maxLeftVol = Number((this.leftVol / 1000));
       return currentVol <= maxLeftVol ? currentVol : maxLeftVol;
     },
     currentRightVol() {
       let currentVol = Number(
-        (((this.rightIncrease / this.rate) * this.rightArea) / 1000).toFixed(4)
+        (((this.rightIncrease / this.rate) * this.rightArea) / 1000)
       );
-      let maxRightVol = Number((this.rightVol / 1000).toFixed(4));
+      let maxRightVol = Number((this.rightVol / 1000));
       return currentVol <= maxRightVol ? currentVol : maxRightVol;
     },
     showCylindars() {
@@ -201,6 +202,8 @@ export default {
     }
   },
   methods: {
+    legify,
+
     /** Calculate cylinder's radius, volume */
     initData() {
       if (this.paperSize.length >= this.paperSize.width) {

--- a/src/components/lessons/dice-basketball/ChanceOfDrawApp.vue
+++ b/src/components/lessons/dice-basketball/ChanceOfDrawApp.vue
@@ -3,10 +3,10 @@
 		<div class="container mt-3 mb-5">
 			<div class="app--title mb-3">
 				<h4 class="text-success">
-					Total games: {{ trialNumber }}
+					Total games: {{ legify(trialNumber) }}
 				</h4>
 				<h4 class="text-success">
-					Games played: {{ numberTried }}
+					{{ legify(numberTried) }} games played
 				</h4>
 			</div>
 			<div class="row mb-2">
@@ -128,7 +128,7 @@
 import ChangeRule from './ChangeRule.vue';
 import DemoAutoOption from './DemoAutoOption.vue';
 import { throwDiceOnce, throwDiceThree } from './utils';
-import { calculateTimerInterval } from '../../common/utils';
+import { calculateTimerInterval, legify } from '../../common/utils';
 export default {
 	props: ['trialNumber'],
 	components: {
@@ -225,6 +225,7 @@ export default {
 		}
 	},
 	methods: {
+		legify,
 		initTallyTable() {
 			for(let i = 0; i<=120; i++) {
 				// i - the difference between team A and team B's points

--- a/src/components/lessons/dice-basketball/PlayManyGamesApp.vue
+++ b/src/components/lessons/dice-basketball/PlayManyGamesApp.vue
@@ -2,8 +2,8 @@
   <div>
     <div class="mt-3 mb-5">
       <div class="app--title mb-3">
-        <h4 class="text-success">Total games: {{ trialNumber }}</h4>
-        <h4 class="text-success">Games played: {{ numberTried }}</h4>
+        <h4 class="text-success">Total games: {{ legify(trialNumber) }}</h4>
+        <h4 class="text-success">{{ legify(numberTried) }} games played</h4>
       </div>
       <div class="app--score-table">
         <table class="table">
@@ -19,26 +19,26 @@
           <tbody>
             <tr>
               <th class="text-danger">Average number</th>
-              <td>{{ averageNumberFor3Point ? averageNumberFor3Point : '' }}</td>
-              <td>{{ averageNumberFor2Point ? averageNumberFor2Point : '' }}</td>
-              <td>{{ averageNumberFor1Point ? averageNumberFor1Point : '' }}</td>
+              <td>{{ averageNumberFor3Point ? averageNumberFor3Point.toFixed(2) : '' }}</td>
+              <td>{{ averageNumberFor2Point ? averageNumberFor2Point.toFixed(2) : '' }}</td>
+              <td>{{ averageNumberFor1Point ? averageNumberFor1Point.toFixed(2) : '' }}</td>
               <td></td>
             </tr>
             <tr>
               <th class="text-danger">Total</th>
-              <td>{{ totalNumberFor3Point ? separateNumber(totalNumberFor3Point * 3) : '' }}</td>
-              <td>{{ totalNumberFor2Point ? separateNumber(totalNumberFor2Point * 2) : '' }}</td>
-              <td>{{ totalNumberFor1Point ? separateNumber(totalNumberFor1Point * 1) : '' }}</td>
+              <td>{{ totalNumberFor3Point ? legify(totalNumberFor3Point * 3) : '' }}</td>
+              <td>{{ totalNumberFor2Point ? legify(totalNumberFor2Point * 2) : '' }}</td>
+              <td>{{ totalNumberFor1Point ? legify(totalNumberFor1Point * 1) : '' }}</td>
               <td
                 class="text-primary"
-              >{{ totalNumberForAll ? separateNumber(totalNumberForAll) : '' }}</td>
+              >{{ totalNumberForAll ? legify(totalNumberForAll) : '' }}</td>
             </tr>
             <tr>
               <th class="text-danger">Average Points</th>
-              <td>{{ averagePointsFor3Point ? averagePointsFor3Point : '' }}</td>
-              <td>{{ averagePointsFor2Point ? averagePointsFor2Point : '' }}</td>
-              <td>{{ averagePointsFor1Point ? averagePointsFor1Point : '' }}</td>
-              <td class="text-primary">{{ averagePointsForAll ? averagePointsForAll : '' }}</td>
+              <td>{{ averagePointsFor3Point ? averagePointsFor3Point.toFixed(2) : '' }}</td>
+              <td>{{ averagePointsFor2Point ? averagePointsFor2Point.toFixed(2) : '' }}</td>
+              <td>{{ averagePointsFor1Point ? averagePointsFor1Point.toFixed(2) : '' }}</td>
+              <td class="text-primary">{{ averagePointsForAll ? averagePointsForAll.toFixed(2) : '' }}</td>
             </tr>
           </tbody>
         </table>
@@ -76,7 +76,7 @@
 import ChangeRule from "./ChangeRule.vue";
 import DemoAutoOption from "./DemoAutoOption.vue";
 import { throwDiceOnce, throwDiceThree } from "./utils.js";
-import { calculateTimerInterval, separateNumber } from "../../common/utils";
+import { calculateTimerInterval, legify } from "../../common/utils";
 export default {
   props: ["trialNumber"],
   components: {
@@ -99,8 +99,7 @@ export default {
       totalNumberFor1Point: 0,
       averageNumberFor3Point: 0,
       averageNumberFor2Point: 0,
-      averageNumberFor1Point: 0,
-      separateNumber
+      averageNumberFor1Point: 0
     };
   },
   computed: {
@@ -160,6 +159,7 @@ export default {
     }
   },
   methods: {
+    legify,
     playOneGame() {
       if (this.isChangeRule) {
         // If rule is changed

--- a/src/components/lessons/dice-basketball/PointDistributionApp.vue
+++ b/src/components/lessons/dice-basketball/PointDistributionApp.vue
@@ -2,8 +2,8 @@
   <div>
     <div class="container mt-3 mb-5">
       <div class="app--title mb-3">
-        <h4 class="text-success">Total games: {{ trialNumber }}</h4>
-        <h4 class="text-success">Games played: {{ numberTried }}</h4>
+        <h4 class="text-success">Total games: {{ legify(trialNumber) }}</h4>
+        <h4 class="text-success">{{ legify(numberTried) }} games played</h4>
       </div>
       <div class="row mb-5">
         <div class="col-12 col-md-3 col-sm-4 app--tally-table">
@@ -81,7 +81,7 @@
 import ChangeRule from "./ChangeRule.vue";
 import DemoAutoOption from "./DemoAutoOption.vue";
 import { throwDiceOnce, throwDiceThree } from "./utils.js";
-import { calculateTimerInterval } from "../../common/utils";
+import { calculateTimerInterval, legify } from "../../common/utils";
 export default {
   props: ["trialNumber"],
   components: {
@@ -155,6 +155,7 @@ export default {
     }
   },
   methods: {
+    legify,
     calculatePointsInOneGame() {
       if (this.isChangeRule) {
         // If rule is changed

--- a/src/components/lessons/dice-cricket/ManyMatchesTable.vue
+++ b/src/components/lessons/dice-cricket/ManyMatchesTable.vue
@@ -86,7 +86,7 @@ export default {
       for (let i = 0; i < this.gameData.length; i++) {
         total += this.gameData[i];
       }
-      return Number((total / this.gameData.length).toFixed(1));
+      return (total / this.gameData.length).toFixed(1);
     },
     meanOvers() {
       return (this.overCounts / 6 / (this.gamePlayedNumber * 2)).toFixed(2);
@@ -95,10 +95,10 @@ export default {
       let middle = this.gameData.length / 2;
       let inMiddle = this.gameData.length % 2;
       return inMiddle === 0
-        ? Number(
+        ?
             ((this.gameData[middle - 1] + this.gameData[middle]) / 2).toFixed(1)
-          )
-        : Number(this.gameData[Math.floor(middle)].toFixed(1));
+
+        : this.gameData[Math.floor(middle)].toFixed(1);
     },
     tiesPercent() {
       return Number(((this.ties / this.gamePlayedNumber) * 100).toFixed(2));

--- a/src/components/lessons/dice-cricket/PlayAMatch.vue
+++ b/src/components/lessons/dice-cricket/PlayAMatch.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="mt-4 mb-5">
+  <div class="mt-3 mb-5">
+    <h3 class="lesson-subheading">Play a match</h3>
+    <hr class="subheading-separator">
     <app-play-a-match-app v-if="matchSetting" :matchSetting="matchSetting"></app-play-a-match-app>
     <app-set-match v-else @setMatch="matchSetting=$event"></app-set-match>
   </div>

--- a/src/components/lessons/dice-cricket/PlayAMatchApp.vue
+++ b/src/components/lessons/dice-cricket/PlayAMatchApp.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="app--container mt-4 mb-5">
-    <h3 class="lesson-subheading">Play a match</h3>
-    <hr class="subheading-separator">
+  <div class="app--container">
     <h5 class="text-dark text-center">{{ matchSetting.wicketTaker }} takes a wicket</h5>
     <div class="row app--score-table mt-3">
       <div class="col-lg-6">

--- a/src/components/lessons/dice-cricket/PlayManyMatches.vue
+++ b/src/components/lessons/dice-cricket/PlayManyMatches.vue
@@ -1,5 +1,7 @@
 <template>
-	<div class="container mt-4 mb-5">
+	<div class="container mt-3 mb-5">
+		<h3 class="lesson-subheading">Play many matches</h3>
+		<hr class="subheading-separator">
 		<app-play-many-matches-app v-if="trialNumber" :trialNumber="trialNumber"></app-play-many-matches-app>
 		<app-enter-trials-Number v-else @acceptTrialNumber="trialNumber=$event"></app-enter-trials-number>
 	</div>

--- a/src/components/lessons/dice-cricket/PlayManyMatchesApp.vue
+++ b/src/components/lessons/dice-cricket/PlayManyMatchesApp.vue
@@ -1,9 +1,7 @@
 <template>
-  <div class="mt-4 mb-5">
-    <h3 class="lesson-subheading">Play many matches</h3>
-    <hr class="subheading-separator">
+  <div class="container">
     <h3 class="text-success text-center mb-4">
-      <small>{{ gameNumber * 2 }} innings</small>
+      <small>{{ legify(gameNumber * 2) }} innings</small>
     </h3>
     <div class="row">
       <div class="col-md-6">
@@ -116,7 +114,7 @@ import ManyMatchesTable from "./ManyMatchesTable.vue";
 import ManyMatchesGraph from "./ManyMatchesGraph.vue";
 import DemoAutoOption from "../../common/DemoAutoOption.vue";
 import { throwDiceOnce } from "./utils";
-import { calculateTimerInterval } from "../../common/utils";
+import { calculateTimerInterval, legify } from "../../common/utils";
 
 export default {
   props: ["trialNumber"],
@@ -176,6 +174,7 @@ export default {
     }
   },
   methods: {
+    legify,
     playOne() {
       let score = 0;
       let wicket = 0;

--- a/src/components/lessons/dice-differences/ComparingTwo.vue
+++ b/src/components/lessons/dice-differences/ComparingTwo.vue
@@ -11,7 +11,7 @@
                     </div>
                 </div>
                 <div class="row justify-content-end">
-                    <label class="col-sm-4" style="font-weight: bold">Range is 1 to 10000</label>
+                    <label class="col-sm-4" style="font-weight: bold">Range is 1 to {{legify(10000)}}</label>
                 </div>
             </div>
             <div class="top" style="margin-top: 10px;">
@@ -79,8 +79,8 @@
         <div v-else class="container mt-4 mb-5">
             <div class="top" style="border: none">
                 <div class="row justify-content-center">
-                    <label class="col-sm-5 label1" >Number of trials: {{numberoftrials}}</label>
-                    <label class="col-sm-5 label1" >{{trails}} trials</label>
+                    <label class="col-sm-5 label1" >Trials completed: {{legify(numberoftrials)}}</label>
+                    <label class="col-sm-5 label1" >Total trials {{legify(trails)}}</label>
                 </div>
             </div>
             <div class="top">
@@ -170,6 +170,7 @@
 </template>
 
 <script>
+    import { legify } from "../../common/utils.js";
     export default {
         data() {
             return {
@@ -253,6 +254,7 @@
             },
         },
         methods:{
+            legify,
             CheckError(){
                 this.prompt1 = false;
                 this.prompt2 = false;
@@ -286,7 +288,7 @@
                         }
                         else {
                           this.ErrorPrompt = "";
-                          this.ErrorPrompt1 = "Enter the number of trials (1-100000)";
+                          this.ErrorPrompt1 = `Enter the number of trials (1 to ${legify(10000)})`;
                         }
                     }
                 }

--- a/src/components/lessons/dice-differences/Experimental.vue
+++ b/src/components/lessons/dice-differences/Experimental.vue
@@ -11,7 +11,7 @@
                     </div>
                 </div>
                 <div class="row justify-content-end">
-                    <label class="col-sm-4" style="font-weight: bold">Range is 1 to 10000</label>
+                    <label class="col-sm-4" style="font-weight: bold">Range is 1 to {{legify(10000)}}</label>
                 </div>
             </div>
             <div class="top" style="margin-top: 10px; border: none">
@@ -26,8 +26,8 @@
         <div :style="{visibility: !next ? 'hidden' : 'visible' }" class="container mt-4 mb-5">
             <div class="top" style="border: none">
                 <div class="row justify-content-center">
-                    <label class="col-sm-5 label1" >Number of trials: {{numberoftrials}}</label>
-                    <label class="col-sm-5 label1" >{{trails}} trials</label>
+                    <label class="col-sm-5 label1" >Trials completed: {{legify(numberoftrials)}}</label>
+                    <label class="col-sm-5 label1" >Total trials: {{legify(trails)}}</label>
                 </div>
             </div>
             <div class="top" style="border: none;margin-top: 20px; min-height: 500px">
@@ -43,7 +43,7 @@
                     <div class="label2" :style="{left: positionLeft - 148 + 'px',top: positionTop + 'px'}">Tally: </div>
                     <div class="label2" :style="{left: positionLeft - 148 + 'px',top: positionTop + 50 + 'px'}">Dice Difference: </div>
                     <div v-for="i in 6" :key="i">
-                        <div class="axis" :style="{left: positionLeft - 100 + 100*i + 'px', top: positionTop + 'px'}">{{nums[i-1]}}</div>
+                        <div class="axis" :style="{left: positionLeft - 100 + 100*i + 'px', top: positionTop + 'px'}">{{legify(nums[i-1])}}</div>
                     </div>
                     <div v-for="j in 6" :key="j+6">
                         <div class="axis1" :style="{left: positionLeft - 100 + 100*j + 'px',top: positionTop + 50 + 'px'}" v-text="j-1"></div>
@@ -67,6 +67,7 @@
 
 <script>
     import BarChart from 'pure-vue-chart';
+    import { legify } from "../../common/utils.js";
     export default {
         data() {
             return {
@@ -116,6 +117,7 @@
             // window.removeEventListener("resize");
         },
         methods:{
+            legify,
             CheckError(){
               if (this.trails > 0) this.next = true;
               else this.error = true;

--- a/src/components/lessons/dice-differences/PlayGames.vue
+++ b/src/components/lessons/dice-differences/PlayGames.vue
@@ -11,7 +11,7 @@
                     </div>
                 </div>
                 <div class="row justify-content-end">
-                    <label class="col-sm-4" style="font-weight: bold">Range is 1 to 10000</label>
+                    <label class="col-sm-4" style="font-weight: bold">Range is 1 to {{ legify(10000) }}</label>
                 </div>
             </div>
             <div class="top" style="margin-top: 10px;">
@@ -49,8 +49,8 @@
         <div v-else class="container mt-4 mb-5">
             <div class="top" style="border: none">
                 <div class="row justify-content-center">
-                    <label class="col-sm-5 label1" >Number of trials: {{numberoftrials}}</label>
-                    <label class="col-sm-5 label1" >{{trails}} trials</label>
+                    <label class="col-sm-5 label1" >Trials completed: {{ legify(numberoftrials)}}</label>
+                    <label class="col-sm-5 label1" >Total trials: {{legify(trails)}}</label>
                 </div>
             </div>
             <div class="top">
@@ -117,6 +117,7 @@
 </template>
 
 <script>
+    import { legify } from "../../common/utils.js";
     export default {
         data() {
             return {
@@ -171,6 +172,7 @@
             },
         },
         methods:{
+            legify,
             CheckError(){
                 this.inputPrompt = false;
                 let sum = Number.parseInt(this.num1)+ Number.parseInt(this.num2) + Number.parseInt(this.num3) + Number.parseInt(this.num4) + Number.parseInt(this.num5) + Number.parseInt(this.num6);

--- a/src/components/lessons/dice-footy/PlayManyGamesApp.vue
+++ b/src/components/lessons/dice-footy/PlayManyGamesApp.vue
@@ -17,16 +17,16 @@
         </thead>
         <tbody>
           <tr>
-            <th>Total</th>
+            <th>This game</th>
             <td>{{ goals > 0 && demoAutoOption==='0' ? goals : '' }}</td>
             <td>{{ behinds > 0 && demoAutoOption==='0' ? behinds : '' }}</td>
             <td>{{ points > 0 && demoAutoOption==='0' ? points : '' }}</td>
           </tr>
           <tr>
             <th>Average</th>
-            <td>{{ averageGoals > 0 ? averageGoals : '' }}</td>
-            <td>{{ averageBehinds > 0 ? averageBehinds : '' }}</td>
-            <td>{{ averagePoints > 0 ? averagePoints : ''}}</td>
+            <td>{{ averageGoals > 0 ? averageGoals.toFixed(2) : '' }}</td>
+            <td>{{ averageBehinds > 0 ? averageBehinds.toFixed(2) : '' }}</td>
+            <td>{{ averagePoints > 0 ? averagePoints.toFixed(2) : ''}}</td>
           </tr>
         </tbody>
       </table>
@@ -64,7 +64,7 @@ import LessonTitle from "./LessonTitle.vue";
 import ChangeRule from "./ChangeRule.vue";
 import DemoAutoOption from "./DemoAutoOption.vue";
 import { throwDiceOnce, throwDiceTwo } from "./utils.js";
-import { calculateTimerInterval } from "../../common/utils";
+import { calculateTimerInterval, legify } from "../../common/utils";
 
 export default {
   props: ["trialNumber"],
@@ -135,6 +135,7 @@ export default {
     }
   },
   methods: {
+    legify,
     playOneGame() {
       if (this.isChangeRule) {
         // If rule is changed

--- a/src/components/lessons/doctor-dart/PlayAGame.vue
+++ b/src/components/lessons/doctor-dart/PlayAGame.vue
@@ -160,7 +160,7 @@
                     return "The tally is too small. Click on the reset button for a new attempt."
                 }else{
                     this.Reached = true;
-                    return "Target reached !  Tap here for new target ";
+                    return "Target reached !  New target ";
                 }
             },
         },

--- a/src/components/lessons/doctor-dart/PlayAGame.vue
+++ b/src/components/lessons/doctor-dart/PlayAGame.vue
@@ -50,7 +50,7 @@
                     <div v-if="IsOk===false">
                         <form @submit.prevent="handleInput">
                             <div class="form-group">
-                                <label for="length-input" class="col" style="font-size: 25px; margin-bottom: 20px">Enter target score(1-99)</label>
+                                <label for="length-input" class="col" style="font-size: 25px; margin-bottom: 20px">Enter target score (1 to 99)</label>
                                 <div class="col-sm-7">
                                     <input
                                             type="number"

--- a/src/components/lessons/duelling-dice/ManyTrials.vue
+++ b/src/components/lessons/duelling-dice/ManyTrials.vue
@@ -6,7 +6,7 @@
             <div class="text-center">
                 <div class="row">
                     <label class="col-form-label col-sm-6">
-                        Enter the number of trials(100 - 10000):
+                        Enter the number of trials (100 to {{legify(10000)}}):
                     </label>
                     <div class="col-sm-6">
                         <input type="number" class="form-control" v-model="trialNum" required> <label id="input" style="color: red; margin-left: 10px"></label>
@@ -89,8 +89,8 @@
                         <td v-for="i in gameRule.diceFaces">{{gameRule.blackDiceFace[i]}}</td>
                     </tr>
                     <tr>
-                        <td :colspan="gameRule.diceFaces/2">Game {{count}}</td>
-                        <td :colspan="gameRule.diceFaces/2">Trials {{trialNum}}</td>
+                        <td :colspan="gameRule.diceFaces/2">Game {{legify(count)}}</td>
+                        <td :colspan="gameRule.diceFaces/2">Trials {{legify(trialNum)}}</td>
                     </tr>
 
                 </table>
@@ -121,6 +121,7 @@
 
 <script>
     import DemoAutoOption from "./DemoAutoOption.vue";
+    import { legify } from "../../common/utils.js";
     export default {
         components: {
             appDemoAutoOption: DemoAutoOption
@@ -217,6 +218,7 @@
         mounted: function() {},
         updated: function() {},
         methods: {
+            legify,
             diceChoose(dice) {
                 if (dice === "red") {
                     this.isRed = !this.isRed;
@@ -243,7 +245,7 @@
                 if (!this.isValidInput) {
                     document.getElementById("outOfRange").innerHTML = "Number of trials out of range!";
                 } else if (this.activatedDices.length < 2) {
-                    document.getElementById("outOfRange").innerHTML = "Please select more than 2 dices!";
+                    document.getElementById("outOfRange").innerHTML = "Please select at least 2 dice!";
                 } else {
                     document.getElementById("outOfRange").innerHTML = "";
                     this.isSet = true;

--- a/src/components/lessons/first-down-to-mountain/GameGraph.vue
+++ b/src/components/lessons/first-down-to-mountain/GameGraph.vue
@@ -24,11 +24,11 @@
       </div>
       <div class="app--graph-statistic d-flex flex-grow-1">
         <div v-for="(item, index) in game" :key="index" class="app--graph-col app--graph-stat-col">
-          <div class="text-primary app--graph-block">{{ item.wins }}</div>
+          <div class="text-primary app--graph-block">{{ legify(item.wins) }}</div>
           <div
             class="app--graph-block"
             :style="{visibility: tried >0?'visible': 'hidden' }"
-          >{{ tried > 0 ? Number((item.wins/tried*100).toFixed(2))+'%' : '0' }}</div>
+          > {{ tried > 0 ? (item.wins / tried*100).toFixed(2) + '%' : '0' }} </div>
           <div class="text-danger app--graph-block">{{ item.diceSums }}</div>
           <div class="app--graph-block">{{ item.spaces }}</div>
         </div>
@@ -39,7 +39,11 @@
 </template>
 
 <script>
+import { legify } from "../../common/utils.js";
 export default {
+  methods: {
+    legify,
+  },
   props: ["game", "tried", "trialNumber", "gameType"],
   data: function() {
     return {};

--- a/src/components/lessons/first-down-to-mountain/ManyGamesApp.vue
+++ b/src/components/lessons/first-down-to-mountain/ManyGamesApp.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="container mt-3">
     <div class="d-flex justify-content-around">
-      <h5>{{ trialNumber}} trials</h5>
-      <h5>Trial {{ tried }}</h5>
+      <h5>{{ legify(trialNumber)}} trials</h5>
+      <h5>Trial {{ legify(tried) }}</h5>
     </div>
 
     <div class="app--game-graph-container">
@@ -37,7 +37,7 @@ import _ from "lodash";
 import { demoGame } from "./game";
 import GameGraph from "./GameGraph.vue";
 import DemoAutoOption from "../../common/DemoAutoOption";
-import { throwDiceOnce, calculateTimerInterval } from "../../common/utils";
+import { throwDiceOnce, calculateTimerInterval, legify } from "../../common/utils";
 
 export default {
   components: {
@@ -66,6 +66,7 @@ export default {
     }
   },
   methods: {
+    legify,
     initGame() {
       this.demoGame = _.cloneDeep(demoGame);
     },

--- a/src/components/lessons/game-show/EnterTrialsNumber.vue
+++ b/src/components/lessons/game-show/EnterTrialsNumber.vue
@@ -2,7 +2,7 @@
     <div>
         <div class="app--enter-number form-group row mt-5">
             <label for="trial-numbers" class="col-form-label col-sm-6">
-                Enter the number of trials(100 - 100000):
+                Enter the number of trials (100 to {{legify(100000)}}):
             </label>
             <div class="col-sm-6">
                 <input type="number" class="form-control" v-model="trialNum" required>
@@ -19,6 +19,7 @@
 </template>
 
 <script>
+    import { legify } from "../../common/utils.js";
     export default {
         data: function() {
             return {
@@ -37,6 +38,7 @@
             }
         },
         methods: {
+            legify,
             handleAcceptTrialNumber() {
                 this.$emit('acceptTrialNumber', this.trialNum);
             }

--- a/src/components/lessons/game-show/FastGame.vue
+++ b/src/components/lessons/game-show/FastGame.vue
@@ -14,12 +14,12 @@
           <td
             style="width: 30%; font-size:25px;color: green;text-align: center;"
           >
-            {{ wins }}
+            {{ legify(wins) }}
           </td>
           <td
             style="width: 30%; font-size:25px;color: green;text-align: center;"
           >
-            {{ winsPersentage }}%
+            {{ winsPercentage.toFixed(2) }}%
           </td>
         </tr>
         <tr>
@@ -29,12 +29,12 @@
           <td
             style="font-size:25px;color: green;text-align: center; width: 100%"
           >
-            {{ losses }}
+            {{ legify(losses) }}
           </td>
           <td
             style="font-size:25px;color: green;text-align: center; width: 100%"
           >
-            {{ lossesPersentage }}%
+            {{ lossesPersentage.toFixed(2) }}%
           </td>
         </tr>
         <tr>
@@ -44,7 +44,7 @@
             >
           </td>
           <td style="font-size:25px;text-align: center; width: 100%">
-            {{ counter }}
+            {{ legify(counter) }}
           </td>
           <td></td>
         </tr>
@@ -55,7 +55,7 @@
             >
           </td>
           <td style="font-size:25px;text-align: center; width: 100%">
-            {{ trialNum }}
+            {{ legify(trialNum) }}
           </td>
           <td></td>
         </tr>
@@ -133,6 +133,7 @@
 
 <script>
 import DemoAutoOption from "./DemoAutoOption.vue";
+import { legify } from "../../common/utils.js";
 export default {
   props: ["trialNum"],
   components: {
@@ -147,7 +148,7 @@ export default {
       finalNum: -1,
       wins: 0,
       losses: 0,
-      winsPersentage: 0,
+      winsPercentage: 0,
       lossesPersentage: 0,
       counter: 0,
       timer: null,
@@ -204,6 +205,7 @@ export default {
   },
   mounted: function() {},
   methods: {
+    legify,
     btnYes() {
       this.ifChange = true;
     },
@@ -291,27 +293,22 @@ export default {
     },
     updatePersentage() {
       if (this.ifChange) {
-        this.lossesPersentage = this.calculatePrecentage(this.wins, this.counter);
-        this.winsPersentage = this.calculatePrecentage(
+        this.lossesPersentage = this.calculatePercentage(this.wins, this.counter);
+        this.winsPercentage = this.calculatePercentage(
                 this.losses,
                 this.counter
         );
       }else{
-        this.winsPersentage = this.calculatePrecentage(this.wins, this.counter);
-        this.lossesPersentage = this.calculatePrecentage(
+        this.winsPercentage = this.calculatePercentage(this.wins, this.counter);
+        this.lossesPersentage = this.calculatePercentage(
                 this.losses,
                 this.counter
         );
       }
     },
 
-    calculatePrecentage(Numerator, denominator) {
-      let temp = (Numerator * 100) / denominator;
-      if (Math.round(temp) == temp) {
-        return temp;
-      } else {
-        return temp.toFixed(2);
-      }
+    calculatePercentage(num, total) {
+      return (num / total * 100);
     },
     reset() {
       this.arr = new Array(3);
@@ -321,7 +318,7 @@ export default {
       this.finalNum = -1;
       this.wins = 0;
       this.losses = 0;
-      this.winsPersentage = 0;
+      this.winsPercentage = 0;
       this.lossesPersentage = 0;
       this.counter = 0;
       this.checkGroup = true;

--- a/src/components/lessons/goldbachs-conjecture/AListofPrimes.vue
+++ b/src/components/lessons/goldbachs-conjecture/AListofPrimes.vue
@@ -21,7 +21,7 @@
                                     id="controlBtn"
                                     v-if="!isSet"
                             >
-                                Show the first 15,000 prime numbers
+                                Show the first {{legify(15000)}} prime numbers
                             </button>
                         </td>
                     </tr>
@@ -45,9 +45,9 @@
 </template>
 
 <script>
-    import {
-        getPrimes,
-    } from "./utils";
+    import { getPrimes } from "./utils";
+    import { legify } from "../../common/utils.js";
+
     export default {
         data: function() {
             return {
@@ -69,7 +69,7 @@
             },
         },
         methods: {
-
+            legify,
             onShowPrimeClicked () {
                 document.getElementById("error").innerHTML = "Please wait.....";
                 var start = new Date().getTime();
@@ -77,7 +77,7 @@
                 let count = 1;
                 while (primes.length >= 200){ //To make faster.....
                     let a = document.getElementById("mainTable").innerHTML + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + count + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(count) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -89,7 +89,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+10) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+10)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -101,7 +101,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+20) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+20)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -113,7 +113,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+30) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+30)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -125,7 +125,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+40) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+40)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -137,7 +137,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+50) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+50)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -149,7 +149,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+60) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+60)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -161,7 +161,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+70) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+70)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -173,7 +173,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+80) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+80)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -185,7 +185,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+90) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+90)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -197,7 +197,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+100) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+100)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -209,7 +209,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+110) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+110)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -221,7 +221,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+120) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+120)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -233,7 +233,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+130) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+130)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -245,7 +245,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+140) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+140)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -257,7 +257,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+150) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+150)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -269,7 +269,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+160) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+160)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -281,7 +281,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+170) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+170)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -293,7 +293,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+180) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+180)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
@@ -305,7 +305,7 @@
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '</tr>' + '<tr>'
-                        + '<td style = "text-align: right; color: red" >' + parseInt(count+190) + '</td>'
+                        + '<td style = "text-align: right; color: red" >' + legify(parseInt(count+190)) + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'
                         + '<td style = "text-align: right;">' + primes.shift() + '</td>'

--- a/src/components/lessons/goldbachs-conjecture/utils.js
+++ b/src/components/lessons/goldbachs-conjecture/utils.js
@@ -1,10 +1,11 @@
+import { legify } from "../../common/utils.js";
 
 export const getPrimes = (n) => {
 	var sieve = [],
 		primes = [];
 	for (let i = 2; i <= n; ++i) {
 		if (!sieve[i]) {
-			primes.push(i);
+			primes.push(legify(i));
 			for (let j = i << 1; j <= n; j += i) {
 				sieve[j] = true;
 			}

--- a/src/components/lessons/greedy-pig/StrategyTable.vue
+++ b/src/components/lessons/greedy-pig/StrategyTable.vue
@@ -3,7 +3,7 @@
     <div class="col-4">
       <h5 style="visibility: hidden;">{{ tableData2 && tableData2.count }}</h5>
       <h5 class="text-danger" v-if="tableData2">{{ tableData2.max }}</h5>
-      <h5 class="text-danger" v-if="tableData2">{{ tableData2.mean }}</h5>
+      <h5 class="text-danger" v-if="tableData2">{{ tableData2.mean.toFixed(2) }}</h5>
       <h5 class="text-danger" v-if="tableData2 && tableData2.count >= 5">
         {{ tableData2.median }}
       </h5>
@@ -17,7 +17,7 @@
     <div class="col-4">
       <h5>{{ tableData1.count }}</h5>
       <h5 class="text-primary">{{ tableData1.max }}</h5>
-      <h5 class="text-primary">{{ tableData1.mean }}</h5>
+      <h5 class="text-primary">{{ tableData1.mean.toFixed(2) }}</h5>
       <h5 class="text-primary" v-if="tableData1.count >= 5">
         {{ tableData1.median }}
       </h5>

--- a/src/components/lessons/greedy-pig/TestingTheories.vue
+++ b/src/components/lessons/greedy-pig/TestingTheories.vue
@@ -65,7 +65,7 @@
           </div>
         </div>
         <div v-if="status === 4" class="text-center">
-          <button class="btn btn-outline-dark" @click="handleReset">Tap here to reset</button>
+          <button class="btn btn-outline-dark" @click="handleReset">Reset</button>
           <div class="text-danger text-center">Finished</div>
         </div>
       </div>

--- a/src/components/lessons/have-a-hexagon/NumberOccursApp.vue
+++ b/src/components/lessons/have-a-hexagon/NumberOccursApp.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="container mt-3 mb-5">
     <h3 class="lesson-subheading">
-      The number of times each product occurs - {{ trialNumber }} trials
+      The number of times each product occurs - {{ legify(trialNumber) }} trials
     </h3>
     <hr class="subheading-separator">
-    <h5 class="text-center">Trial {{ numberOfTrials }}</h5>
+    <h5 class="text-center">Trial {{ legify(numberOfTrials) }}</h5>
     <div class="app--table">
       <div
         class="app--table-row"
@@ -54,7 +54,7 @@
 <script>
 import DemoAutoOption from "../../common/DemoAutoOption";
 import { throwDiceOnce } from "./utils";
-import { calculateTimerInterval } from "../../common/utils";
+import { calculateTimerInterval, legify } from "../../common/utils";
 
 export default {
   components: {
@@ -104,6 +104,7 @@ export default {
     }
   },
   methods: {
+    legify,
     handlePlayOneGame() {
       if (!this.isStart) this.isStart = true;
       let product = throwDiceOnce() * throwDiceOnce();

--- a/src/components/lessons/have-a-hexagon/PlayManyGames.vue
+++ b/src/components/lessons/have-a-hexagon/PlayManyGames.vue
@@ -65,7 +65,7 @@
         <label
           for="trial-numbers"
           class="col-form-label col-sm-6"
-        >Enter the number of trials (1 to 10000):</label>
+        >Enter the number of trials (1 to {{legify(10000)}}):</label>
         <div class="col-sm-6">
           <input type="number" class="form-control" v-model="trialNumber" required />
         </div>
@@ -100,7 +100,7 @@
         <tr v-if="selectedHex.length > 1">
           <td>% Wins</td>
           <td v-for="(percent, index) in resultPercent" :key="index">
-            <span v-if="percent > 0">{{percent}}%</span>
+            <span v-if="percent > 0">{{percent.toFixed(2)}}%</span>
             &nbsp;
           </td>
         </tr>
@@ -114,17 +114,17 @@
         <tr v-if="selectedHex.length > 1">
           <td># Wins</td>
           <td v-for="(item, index) in result" :key="index">
-            <span v-if="item > 0">{{ item }}</span>
+            <span v-if="item > 0">{{ legify(item) }}</span>
             &nbsp;
           </td>
         </tr>
         <tr>
           <td>Trial</td>
           <td>
-            <span v-if="numberOfTried > 0" class="text-primary">{{ numberOfTried}}&nbsp;</span>
+            <span v-if="numberOfTried > 0" class="text-primary">{{ legify(numberOfTried) }}&nbsp;</span>
           </td>
           <td></td>
-          <td class="text-danger" v-if="trialNumber">{{trialNumber}} trials</td>
+          <td class="text-danger" v-if="trialNumber">{{legify(trialNumber)}} trials</td>
         </tr>
       </table>
       <div class="text-center mt-3">
@@ -158,7 +158,7 @@
 import Hexagon from "./Hexagon.vue";
 import DemoAutoOption from "../../common/DemoAutoOption.vue";
 import { throwDiceOnce } from "./utils";
-import { calculateTimerInterval } from "../../common/utils";
+import { calculateTimerInterval, legify } from "../../common/utils";
 
 export default {
   components: {
@@ -208,6 +208,7 @@ export default {
     }
   },
   methods: {
+    legify,
     handlePlayOneGame() {
       if (!this.isStart) this.isStart = true;
       this.numberOfTried++;
@@ -318,9 +319,7 @@ export default {
       }
       const resultPercentArr = [];
       for (let i = 0; i < this.result.length; i++) {
-        let percent = Number(
-          ((this.result[i] / this.numberOfTried) * 100).toFixed(1)
-        );
+        let percent = ((this.result[i] / this.numberOfTried) * 100);
         resultPercentArr.push(percent);
       }
       return resultPercentArr;

--- a/src/components/lessons/make-a-million/MakeAMillion.vue
+++ b/src/components/lessons/make-a-million/MakeAMillion.vue
@@ -6,15 +6,15 @@
 					<div class="app--counting-table-container mb-5">
 						<div class="app--counting-label">
 							<div class="app--counting-label-line1">
-								<div>1,000,000s</div>
-								<div style="transform: translateX(-30%);">10,000s</div>
-								<div style="transform: translateX(-80%);">100s</div>
-								<div style="transform: translateX(-50%);">1s</div>
+								<div>{{legify(1000000)}}s</div>
+								<div style="transform: translateX(-30%);">{{legify(10000)}}s</div>
+								<div style="transform: translateX(-80%);">{{legify(100)}}s</div>
+								<div style="transform: translateX(-50%);">{{legify(1)}}s</div>
 							</div>
 							<div class="app--counting-label-line2">
-								<div>100,000s</div>
-								<div style="transform: translateX(-30%);">1,000s</div>
-								<div>10s</div>
+								<div>{{legify(100000)}}s</div>
+								<div style="transform: translateX(-30%);">{{legify(1000)}}s</div>
+								<div>{{legify(10)}}s</div>
 							</div>
 						</div>
 						<div class="app--counting-table">
@@ -56,7 +56,7 @@
 						<div class="app--calculator">
 							<div class="app--calculator-inner">
 								<div class="app--calculator-input">
-									{{ count }}
+									{{ legify(count) }}
 								</div>
 								<div class="app--calculator-panel">
 									<div class="app--calculator-row">
@@ -180,6 +180,8 @@
 
 <script>
 import converter from 'number-to-words';
+import { legify } from "../../common/utils.js";
+
 export default {
 	data: function() {
 		return {
@@ -233,6 +235,7 @@ export default {
 		}
 	},
 	methods: {
+		legify,
 		handleToggleTimer() {
 			if(!this.isStart) {
 				this.isStart = true;

--- a/src/components/lessons/maths-of-lotto/IsEqualGroupApp.vue
+++ b/src/components/lessons/maths-of-lotto/IsEqualGroupApp.vue
@@ -3,8 +3,8 @@
     <h5
       class="text-center"
     >Draw {{ settings.numbersToDraw }} numbers from {{ settings.totalNumbers }} numbers</h5>
-    <p class="text-center" v-if="triedNumber===0">Play {{ trialNumber }} games</p>
-    <p class="text-center" v-else>Played {{ triedNumber }} of {{ trialNumber}} games</p>
+    <p class="text-center" v-if="triedNumber===0">Play {{ legify(trialNumber) }} games</p>
+    <p class="text-center" v-else>Played {{ legify(triedNumber) }} of {{ legify(trialNumber) }} games</p>
 
     <div style="width: 80%; margin: 0 auto; height: auto; max-height: 500px; overflow-y: scroll;">
       <table class="table table-bordered text-center">
@@ -19,10 +19,10 @@
           <tr v-for="(el, index) in cmbArr" :key="index">
             <td>{{el.cmb.join(',')}}</td>
             <td>
-              <span v-if="el.win>0">{{ el.win }}</span>
+              <span v-if="el.win>0">{{ legify(el.win) }}</span>
             </td>
             <td>
-              <span v-if="el.win>0">{{ Number(((el.win / triedNumber)*100).toFixed(1)) }} %</span>
+              <span v-if="el.win>0">{{ ((el.win / triedNumber)*100).toFixed(1) }} %</span>
             </td>
           </tr>
         </tbody>
@@ -54,7 +54,7 @@
 <script>
 import Combinatorics from "js-combinatorics";
 import DemoAutoOption from "../../common/DemoAutoOption.vue";
-import { pickNumber, calculateTimerInterval } from "../../common/utils";
+import { pickNumber, calculateTimerInterval, legify } from "../../common/utils.js";
 
 export default {
   components: {
@@ -94,6 +94,7 @@ export default {
     }
   },
   methods: {
+    legify,
     setNumbersToDraw(total) {
       const numbersToDraw = [];
       for (let i = 1; i <= total; i++) {

--- a/src/components/lessons/maths-of-lotto/PlayLotto45.vue
+++ b/src/components/lessons/maths-of-lotto/PlayLotto45.vue
@@ -98,12 +98,12 @@
         <div v-if="showRule">
           <p>45:6 Lotto is played every Saturday night</p>
           <p>There are five prizes</p>
-          <p>Div 1: 6 numbers ($752,604.40)</p>
-          <p>Div 2: 5 numbers plus 1 supplementary number ($14111.30)</p>
-          <p>Div 3: 5 numbers ($1,440.80)</p>
-          <p>Div 4: 4 numbers ($49.80)</p>
-          <p>Div 5: 3 numbers plus 1 supplementary number($32.60)</p>
-          <p>The cost of each game is $0.60</p>
+          <p>Div 1: 6 numbers (${{legify(752604.40, 2)}})</p>
+          <p>Div 2: 5 numbers plus 1 supplementary number (${{legify(14111.30, 2)}})</p>
+          <p>Div 3: 5 numbers (${{legify(1440.80, 2)}})</p>
+          <p>Div 4: 4 numbers (${{legify(49.80, 2)}})</p>
+          <p>Div 5: 3 numbers plus 1 supplementary number(${{legify(32.60, 2)}})</p>
+          <p>The cost of each game is ${{legify(0.60, 2)}}</p>
           <p>Prize amounts approximate average payouts.</p>
         </div>
         <div v-if="status === 2">
@@ -120,12 +120,12 @@
             <tbody>
               <tr v-for="(item, index) in divisionTable" :key="index">
                 <td>{{ item.div }}</td>
-                <td>&dollar; {{ separateFloating(item.prize) }}</td>
+                <td>&dollar; {{ legify(item.prize, 2) }}</td>
                 <td>
                   <span v-if="item.wins>0">{{ item.wins }}</span>
                 </td>
                 <td>
-                  <span v-if="item.amount>0">&dollar; {{ separateFloating(item.amount) }}</span>
+                  <span v-if="item.amount>0">&dollar; {{ legify(item.amount, 2) }}</span>
                 </td>
               </tr>
             </tbody>
@@ -144,17 +144,13 @@
               <th class="text-danger">Cost:</th>
               <td>
                 &dollar;
-                {{
-                separateFloating(
-                Number((gamesPlayed * COST_PER_GAME).toFixed(2))
-                )
-                }}
+                {{ legify(gamesPlayed * COST_PER_GAME, 2) }}
               </td>
             </tr>
             <tr>
               <th class="text-primary">Winnings:</th>
               <td>
-                <span v-if="totalWinningMoney > 0">&dollar; {{ separateFloating(totalWinningMoney) }}</span>
+                <span v-if="totalWinningMoney > 0">&dollar; {{ legify(totalWinningMoney, 2) }}</span>
               </td>
             </tr>
           </table>
@@ -220,7 +216,7 @@ import moment from "moment";
 import Combinatorics from "js-combinatorics";
 import DemoAutoOption from "../../common/DemoAutoOption.vue";
 import { initLottoNumbers } from "./utils";
-import { pickNumber, separateNumber } from "../../common/utils";
+import { pickNumber, legify } from "../../common/utils";
 
 export default {
   components: {
@@ -294,6 +290,7 @@ export default {
     }
   },
   methods: {
+    legify,
     /** Select a number from 45 numbers */
     handleSelectNumber($e) {
       if (this.status === 2) return;
@@ -542,16 +539,6 @@ export default {
 
     handleToggleShowRule() {
       this.showRule = !this.showRule;
-    },
-
-    separateFloating(number) {
-      let strNumber = String(number);
-      let strNumberArr = strNumber.split(".");
-      let integerPart = strNumberArr[0];
-      let decimalPart = strNumberArr[1];
-      return decimalPart
-        ? separateNumber(integerPart) + "." + decimalPart
-        : separateNumber(integerPart);
     }
   },
   created() {

--- a/src/components/lessons/maths-of-lotto/PlayMultipleGamesApp.vue
+++ b/src/components/lessons/maths-of-lotto/PlayMultipleGamesApp.vue
@@ -2,8 +2,8 @@
   <div class="container mt-3">
     <!-- <h3 class="text-success text-center mb-4">multiple {{trialNumber}}</h3> -->
     <app-selection-panel :lottoNumbers="lottoNumbers" @selectNumber="handleSelectNumber"></app-selection-panel>
-    <h6 class="text-center mt-3" v-if="status===0 || status===1 ">Play {{ trialNumber }} games</h6>
-    <h6 class="text-center mt-3" v-else>Played {{ triedGames }} of {{ trialNumber }} games</h6>
+    <h6 class="text-center mt-3" v-if="status===0 || status===1 ">Play {{ legify(trialNumber) }} games</h6>
+    <h6 class="text-center mt-3" v-else>Played {{ legify(triedGames) }} of {{ legify(trialNumber) }} games</h6>
 
     <app-drawn-panel :drawnNumbers="drawnNumbers" :settings="settings" :status="status"></app-drawn-panel>
 
@@ -33,19 +33,19 @@
     <div v-if="status === 2 || status === 3" class="mt-3">
       <table class="table table-bordered text-center" style="table-layout: fixed">
         <tr>
-          <td v-if="winGames > 0">1 win in {{ Number((triedGames / winGames).toFixed(2)) }} games</td>
+          <td v-if="winGames > 0">1 win in {{ (triedGames / winGames).toFixed(2) }} games</td>
           <td v-else>0 wins</td>
           <td>
-            <span v-if="winGames > 0">{{ winGames }} win{{winGames > 1 ? 's' : ''}}</span>
+            <span v-if="winGames > 0">{{ legify(winGames) }} win{{winGames > 1 ? 's' : ''}}</span>
           </td>
         </tr>
         <tr>
           <td>
-            <span v-if="winGames > 0">{{ winPercent }} wins every 100 games</span>
+            <span v-if="winGames > 0">{{ winPercent.toFixed(2) }} wins every 100 games</span>
             <span v-else style="visibility: hidden;">1</span>
           </td>
           <td>
-            <span v-if="winGames > 0">{{ winPercent }}%</span>
+            <span v-if="winGames > 0">{{ winPercent.toFixed(2) }}%</span>
           </td>
         </tr>
       </table>
@@ -54,7 +54,7 @@
 </template>
 
 <script>
-import { pickNumber, calculateTimerInterval } from "../../common/utils";
+import { pickNumber, calculateTimerInterval, legify } from "../../common/utils.js";
 import {
   // lottoNumbers,
   initLottoNumbers,
@@ -131,6 +131,7 @@ export default {
     }
   },
   methods: {
+    legify,
     handleSelectNumber($e) {
       if (!(this.status === 0 || this.status === 1 || this.status === 3)) {
         return;

--- a/src/components/lessons/multo/ManyGamesStat.vue
+++ b/src/components/lessons/multo/ManyGamesStat.vue
@@ -16,7 +16,7 @@
                 ? 'visible'
                 : 'hidden'
             }"
-      >Game {{gameNumber}} of {{trialNumber}}</h5>
+      >Game {{legify(gameNumber)}} of {{legify(trialNumber)}}</h5>
     </div>
     <div>
       <h6 class="ml-2">Wins</h6>
@@ -35,7 +35,11 @@
 </template>
 
 <script>
+import { legify } from "../../common/utils.js";
 export default {
+  methods: {
+    legify,
+  },
   props: [
     "totalCardNumbers",
     "gameNumber",
@@ -48,14 +52,14 @@ export default {
       if (!this.gameNumber) {
         return 0;
       }
-      return String((this.totalCardNumbers / this.gameNumber).toFixed(2));
+      return (this.totalCardNumbers / this.gameNumber).toFixed(2);
     },
     winPercent0() {
       if (!this.gameNumber) {
         return 0;
       }
       return (
-        String(((this.winStats[0] / this.gameNumber) * 100).toFixed(2)) + "%"
+        ((this.winStats[0] / this.gameNumber) * 100).toFixed(2) + "%"
       );
     },
     winPercent1() {
@@ -63,7 +67,7 @@ export default {
         return 0;
       }
       return (
-        String(((this.winStats[1] / this.gameNumber) * 100).toFixed(2)) + "%"
+        ((this.winStats[1] / this.gameNumber) * 100).toFixed(2) + "%"
       );
     },
     winPercent2() {
@@ -71,7 +75,7 @@ export default {
         return 0;
       }
       return (
-        String(((this.winStats[2] / this.gameNumber) * 100).toFixed(2)) + "%"
+        ((this.winStats[2] / this.gameNumber) * 100).toFixed(2) + "%"
       );
     }
   }

--- a/src/components/lessons/nine-and-over/AnyAddition.vue
+++ b/src/components/lessons/nine-and-over/AnyAddition.vue
@@ -37,9 +37,9 @@
             </div>
             <div v-else>
               <h6>
-                Starting number is {{ numberSet.startingNumber }}
+                Starting number is {{ legify(numberSet.startingNumber) }}
                 <br />
-                Target number is {{ numberSet.targetNumber }}
+                Target number is {{ legify(numberSet.targetNumber) }}
               </h6>
               <div class="app--dice text-center mt-4" v-if="diceNumber1 || diceNumber2">
                 <app-dice :index="1" :number="diceNumber1" class="m-1"></app-dice>
@@ -96,6 +96,8 @@ import SpellingBoard from "./SpellingBoard.vue";
 import AddSubForm from "./AddSubForm.vue";
 import Dice from "../../common/Dice.vue";
 import { throwDiceOnce } from "./utils";
+import { legify } from "../../common/utils.js";
+
 
 export default {
   components: {
@@ -140,6 +142,7 @@ export default {
     }
   },
   methods: {
+    legify,
     handleSetNumber($event) {
       // In the beginning of a game, set starting number and target number
       // console.log($event);

--- a/src/components/lessons/nine-and-over/AnySubtraction.vue
+++ b/src/components/lessons/nine-and-over/AnySubtraction.vue
@@ -37,9 +37,9 @@
             </div>
             <div v-else>
               <h6>
-                Starting number is {{ numberSet.startingNumber }}
+                Starting number is {{ legify(numberSet.startingNumber) }}
                 <br />
-                Target number is {{ numberSet.targetNumber }}
+                Target number is {{ legify(numberSet.targetNumber) }}
               </h6>
               <div class="app--dice text-center mt-4" v-if="diceNumber1 || diceNumber2">
                 <app-dice :index="1" :number="diceNumber1" class="m-1"></app-dice>
@@ -96,6 +96,7 @@ import SpellingBoard from "./SpellingBoard.vue";
 import AddSubForm from "./AddSubForm.vue";
 import Dice from "../../common/Dice.vue";
 import { throwDiceOnce } from "./utils";
+import { legify } from "../../common/utils.js";
 
 export default {
   components: {
@@ -140,6 +141,7 @@ export default {
     }
   },
   methods: {
+    legify,
     handleSetNumber($event) {
       // In the beginning of a game, set starting number and target number
       // console.log($event);

--- a/src/components/lessons/nine-and-over/Calculator.vue
+++ b/src/components/lessons/nine-and-over/Calculator.vue
@@ -7,7 +7,7 @@
       <div class="app--cal-input">
         <div class="app--cal-input-operator">{{ operator }}</div>
         <div class="app--cal-input-number">
-          {{ numberCal }}
+          {{ legify(numberCal) }}
           <i
             v-if="numberToCheck && numberToCheck==numberCal"
             class="fas fa-check text-success"
@@ -76,6 +76,8 @@
 </template>
 
 <script>
+import { legify } from "../../common/utils.js";
+
 export default {
   props: [
     "calNumber",
@@ -124,6 +126,7 @@ export default {
     }
   },
   methods: {
+    legify,
     handleReset() {
       if (this.isDisable) return;
       this.operator = null;

--- a/src/components/lessons/nine-and-over/ComputerCount.vue
+++ b/src/components/lessons/nine-and-over/ComputerCount.vue
@@ -34,7 +34,7 @@
 					</div>
 					<div v-else class="pl-3" >
 						<div>
-							Started counting from {{ appStartingNumber }}
+							Started counting from {{ legify(appStartingNumber) }}
 							<br>
 							Counting by {{countingSet.countingBy }}s
 						</div>
@@ -129,6 +129,8 @@ import Calculator from './Calculator.vue';
 import SpellingBoard from './SpellingBoard.vue';
 import CountForm from './CountForm.vue';
 import DemoAutoOption from '../../common/DemoAutoOption.vue';
+import { legify } from "../../common/utils.js";
+
 export default {
 	components: {
 		appPlugboard: Plugboard,
@@ -182,6 +184,7 @@ export default {
 		}
 	},
 	methods: {
+		legify,
 		handleNextNumber() {
 			if(!this.isStart) {
 				this.isStart = true;

--- a/src/components/lessons/nine-and-over/Plugboard.vue
+++ b/src/components/lessons/nine-and-over/Plugboard.vue
@@ -39,8 +39,8 @@
         </div>
 
         <!-- <div class="app--plugboard-number mt-2">
-					<input 
-						class="app--plugboard-number-input" 
+					<input
+						class="app--plugboard-number-input"
 						type="number" :min="0" :max="9"
 						v-model="digital[i-1]"
 						:disabled="(6-i) > totalDigit"
@@ -59,6 +59,7 @@
 </template>
 
 <script>
+import { legify } from "../../common/utils.js";
 export default {
   props: [
     "plugboardNumber",
@@ -74,11 +75,11 @@ export default {
     return {
       totalDigit: 3,
       digitalLabel: [
-        { id: 1, digit: "10,000" },
-        { id: 2, digit: "1,000" },
-        { id: 3, digit: "100" },
-        { id: 4, digit: "10" },
-        { id: 5, digit: "1" }
+        { id: 1, digit: legify(10000) + 's' },
+        { id: 2, digit: legify(1000) + 's' },
+        { id: 3, digit: legify(100) + 's' },
+        { id: 4, digit: legify(10) + 's' },
+        { id: 5, digit: legify(1) + 's' }
       ],
       // isDisable: false,	// If the board is disabled
       // isRadioDisable: false,	// If radio button is disabled

--- a/src/components/lessons/nine-and-over/ShowTheNumber.vue
+++ b/src/components/lessons/nine-and-over/ShowTheNumber.vue
@@ -72,6 +72,8 @@ import Calculator from './Calculator.vue';
 import SpellingBoard from './SpellingBoard.vue';
 import SpellingHelp from './SpellingHelp.vue';
 import { pickRandomNumber } from './utils';
+import { legify } from "../../common/utils.js";
+
 
 export default {
 	components: {
@@ -106,6 +108,7 @@ export default {
 		}
 	},
 	methods: {
+		legify,
 		init() {
 			this.plugboardNumber = null;
 			this.inputNumber = null;

--- a/src/components/lessons/nine-and-over/YouCount.vue
+++ b/src/components/lessons/nine-and-over/YouCount.vue
@@ -35,7 +35,7 @@
 					</div>
 					<div v-else class="pl-3" >
 						<div>
-							Started counting from {{ appStartingNumber }}
+							Started counting from {{ legify(appStartingNumber) }}
 							<br>
 							Counting by {{countingSet.countingBy }}s
 						</div>
@@ -65,6 +65,8 @@ import Calculator from './Calculator.vue';
 import SpellingBoard from './SpellingBoard.vue';
 import CountForm from './CountForm.vue';
 import correctChoiceSound from '@/assets/correct-choice.wav';
+import { legify } from "../../common/utils.js";
+
 
 export default {
 	components: {
@@ -97,6 +99,7 @@ export default {
 		}
 	},
 	methods: {
+		legify,
 		handleSettingNumber($event) {
 			const { direction, countingBy, startingNumber } = this.countingSet;
 			if(startingNumber + direction*countingBy === $event) {

--- a/src/components/lessons/number-partitions/CalculatePartitions.vue
+++ b/src/components/lessons/number-partitions/CalculatePartitions.vue
@@ -46,8 +46,10 @@
 <script>
 import {
   integerPartition,
-  separateNumber /*, bigIntegerPartition*/
+   /* bigIntegerPartition*/
 } from "./utils";
+import { legify } from "../../common/utils.js";
+
 export default {
   data: function() {
     return {
@@ -57,6 +59,7 @@ export default {
     };
   },
   methods: {
+  legify,
     handleCheckNumber(e) {
       let { charCode } = e;
       if (!(charCode >= 48 && charCode <= 57)) {
@@ -76,7 +79,7 @@ export default {
       //   // let temp = bigIntegerPartition[this.numberToPartition - 300 - 1];
       //   // return temp;
       // }
-      this.partitionsNumber = separateNumber(
+      this.partitionsNumber = legify(
         integerPartition(this.numberToPartition)
       );
       this.numberToPartitionResult = this.numberToPartition;

--- a/src/components/lessons/number-partitions/ShowPartitions.vue
+++ b/src/components/lessons/number-partitions/ShowPartitions.vue
@@ -43,7 +43,8 @@
 </template>
 
 <script>
-import { partition, integerPartition, separateNumber, sumArray } from "./utils";
+import { partition, integerPartition, sumArray } from "./utils";
+import { legify } from "../../common/utils.js";
 export default {
   data: function() {
     return {
@@ -54,6 +55,7 @@ export default {
     };
   },
   methods: {
+    legify,
     handleCheckNumber(e) {
       let { charCode } = e;
       if (!(charCode >= 48 && charCode <= 57)) {
@@ -66,9 +68,7 @@ export default {
     handleOk() {
       this.gameStatus = 1;
       this.partitions.push([this.numberToPartition]); // add the first partition
-      this.partitionsNumber = separateNumber(
-        integerPartition(this.numberToPartition)
-      );
+      this.partitionsNumber = legify(integerPartition(this.numberToPartition));
 
       // let tableContainer = document.getElementById("app--table-container");
       partition(this.numberToPartition, p => {

--- a/src/components/lessons/number-partitions/TableOfPartitions.vue
+++ b/src/components/lessons/number-partitions/TableOfPartitions.vue
@@ -14,7 +14,7 @@
             <tbody>
               <tr v-for="(item, index) in dataSetDisplay" :key="index">
                 <td>{{ item.n }}</td>
-                <td class="text-center">{{ separateNumber(item.pn) }}</td>
+                <td class="text-center">{{ legify(item.pn) }}</td>
                 <td v-if="showRatio" class="text-center">{{ item.ratio }}</td>
               </tr>
             </tbody>
@@ -66,7 +66,7 @@
         <canvas id="dataChart" width="400" height="400"></canvas>
         <h6 class="text-center mt-3" v-if="dataSetDisplay.length > 0">
           P({{ dataSetDisplay[dataSetDisplay.length - 1].n }}) =
-          {{ separateNumber(dataSetDisplay[dataSetDisplay.length - 1].pn) }}
+          {{ legify(dataSetDisplay[dataSetDisplay.length - 1].pn) }}
         </h6>
       </div>
     </div>
@@ -75,8 +75,9 @@
 
 <script>
 import Chart from "chart.js";
-import { integerPartition, separateNumber } from "./utils";
+import { integerPartition } from "./utils";
 import DemoAutoOption from "../../common/DemoAutoOption.vue";
+import { legify } from "../../common/utils.js";
 
 export default {
   components: {
@@ -97,7 +98,6 @@ export default {
       chart: null,
       chartLabel: [],
       chartData: [],
-      separateNumber
     };
   },
   computed: {
@@ -129,6 +129,7 @@ export default {
     }
   },
   methods: {
+    legify,
     clearTimer() {
       if (this.timer) {
         clearInterval(this.timer);

--- a/src/components/lessons/number-partitions/utils.js
+++ b/src/components/lessons/number-partitions/utils.js
@@ -146,30 +146,6 @@ export const partition = (n, fn) => {
 };
 
 /**
- * Separate number digits by blanks.
- * e.g. 12345678 => 12,345,678
- * @param {number} number
- */
-export const separateNumber = number => {
-  let strNum = String(number);
-  let arrNum = strNum.split("");
-  let arr = [];
-  let part = "";
-  for (let i = 0; i < arrNum.length; i++) {
-    let num = arrNum[arrNum.length - i - 1];
-    part = num + part;
-    if ((i + 1) % 3 === 0) {
-      arr.unshift(part);
-      part = "";
-    }
-  }
-  if (part.length > 0) {
-    arr.unshift(part);
-  }
-  return arr.join(",");
-};
-
-/**
  * Sum up all the numbers in an array
  * @param {Array} arr
  */

--- a/src/components/lessons/odds-and-evens/EnterYourNumber.vue
+++ b/src/components/lessons/odds-and-evens/EnterYourNumber.vue
@@ -10,7 +10,7 @@
         <div>
           <div>
             <label class="instructionLabel"
-              >Enter a number to find its chain (1-999999999):
+              >Enter a number to find its chain (1 to {{legify(999999999)}}):
             </label>
           </div>
           <div style="margin-top: 10px; display:flex; flex-direction: row;">
@@ -96,8 +96,8 @@
                 :style="{ background: j - 1 === idx ? '#f4ffec' : '' }"
                 @click="change(j)"
               >
-                <td>{{ isSet1 ? display[j - 1][0] : "" }}</td>
-                <td>{{ isSet1 ? display[j - 1][1] : "" }}</td>
+                <td>{{ isSet1 ? legify(display[j - 1][0]) : "" }}</td>
+                <td>{{ isSet1 ? legify(display[j - 1][1]) : "" }}</td>
               </tr>
             </thead>
             <tbody></tbody>
@@ -113,7 +113,7 @@
             :style="{
               visibility: isSet ? 'visible' : isSet2 ? 'visible' : 'hidden'
             }"
-            >Chain for {{ useNum }}</label
+            >Chain for {{ legify(useNum) }}</label
           >
         </div>
         <div
@@ -179,6 +179,7 @@
 
 <script>
 import DemoAutoOption from "./DemoAutoOption.vue";
+import { legify } from "../../common/utils.js";
 
 export default {
   components: {
@@ -248,6 +249,7 @@ export default {
     }
   },
   methods: {
+    legify,
     checked() {
       if (this.isSet2) {
         this.enterNum = "";
@@ -301,7 +303,7 @@ export default {
       this.chainLength++;
       object.chainLength = this.chainLength;
       if (this.firstChain) {
-        object.chain[object.chain.length - 1] += this.number;
+        object.chain[object.chain.length - 1] += legify(this.number);
         this.firstChain = false;
       } else {
         if (this.number % 2 === 0) {
@@ -314,10 +316,10 @@ export default {
             this.number.toString().length <
           85
         )
-          object.chain[object.chain.length - 1] += "->" + this.number;
+          object.chain[object.chain.length - 1] += "->" + legify(this.number);
         else {
           object.chain.push("");
-          object.chain[object.chain.length - 1] += this.number;
+          object.chain[object.chain.length - 1] += legify(this.number);
         }
         if (this.numberArr[0].chain.length > 6) {
           this.row = this.numberArr[0].chain.length;
@@ -350,7 +352,7 @@ export default {
       this.chainLength++;
       object.chainLength = this.chainLength;
       if (this.firstChain) {
-        object.chain[object.chain.length - 1] += this.number;
+        object.chain[object.chain.length - 1] += legify(this.number);
         this.firstChain = false;
       } else {
         if (this.number % 2 === 0) {
@@ -363,10 +365,10 @@ export default {
             this.number.toString().length <
           85
         )
-          object.chain[object.chain.length - 1] += "->" + this.number;
+          object.chain[object.chain.length - 1] += "->" + legify(this.number);
         else {
           object.chain.push("");
-          object.chain[object.chain.length - 1] += this.number;
+          object.chain[object.chain.length - 1] += legify(this.number);
         }
         if (this.numberArr[0].chain.length > 6) {
           this.row = this.numberArr[0].chain.length;

--- a/src/components/lessons/odds-and-evens/EnterYourNumberAndSearchRange.vue
+++ b/src/components/lessons/odds-and-evens/EnterYourNumberAndSearchRange.vue
@@ -10,7 +10,7 @@
         <div>
           <div>
             <label id="instructionLabel" class="instructionLabel"
-              >Enter a start number (1-999999999):
+              >Enter a start number (1 to {{legify(999999999)}}):
             </label>
           </div>
           <div style="margin-top: 5px; display:flex; flex-direction: row;">
@@ -135,8 +135,8 @@
                 :style="{ background: j - 1 === idx ? '#f4ffec' : '' }"
                 @click="change(j)"
               >
-                <td>{{ isSet1 ? display[j - 1][0] : "" }}</td>
-                <td>{{ isSet1 ? display[j - 1][1] : "" }}</td>
+                <td>{{ isSet1 ? legify(display[j - 1][0]) : "" }}</td>
+                <td>{{ isSet1 ? legify(display[j - 1][1]) : "" }}</td>
               </tr>
             </thead>
             <tbody></tbody>
@@ -152,7 +152,7 @@
             :style="{
               visibility: isSet ? 'visible' : isSet2 ? 'visible' : 'hidden'
             }"
-            >Chain for {{ useNum }}</label
+            >Chain for {{ legify(useNum) }}</label
           >
         </div>
         <div
@@ -222,6 +222,7 @@
 
 <script>
 import DemoAutoOption from "./DemoAutoOption.vue";
+import { legify } from "../../common/utils.js";
 
 export default {
   components: {
@@ -296,17 +297,18 @@ export default {
     this.start();
   },
   methods: {
+    legify,
     checkInput1() {
       document.getElementById("instructionLabel").innerHTML =
-        "Enter a start number (1-999999999):";
+        "Enter a start number (1 to " + legify(999999999) + "):";
     },
     checkInput2() {
       if (this.enterNum !== "") {
         document.getElementById("instructionLabel").innerHTML =
           "Enter a finish number (" +
-          this.enterNum +
-          "-" +
-          (parseInt(this.enterNum) + 100) +
+          legify(this.enterNum) +
+          " to " +
+          legify(parseInt(this.enterNum) + 100) +
           ")";
       }
     },
@@ -406,7 +408,7 @@ export default {
       this.chainLength++;
       object.chainLength = this.chainLength;
       if (this.firstChain) {
-        object.chain[object.chain.length - 1] += this.number1;
+        object.chain[object.chain.length - 1] += legify(this.number1);
         this.firstChain = false;
       } else {
         if (this.number1 % 2 === 0) {
@@ -419,10 +421,10 @@ export default {
             this.number1.toString().length <
           85
         )
-          object.chain[object.chain.length - 1] += "->" + this.number1;
+          object.chain[object.chain.length - 1] += "->" + legify(this.number1);
         else {
           object.chain.push("");
-          object.chain[object.chain.length - 1] += this.number1;
+          object.chain[object.chain.length - 1] += legify(this.number1);
         }
         if (this.numberArr[0].chain.length > 6) {
           this.row = this.numberArr[0].chain.length;
@@ -438,7 +440,7 @@ export default {
       this.chainLength++;
       object.chainLength = this.chainLength;
       if (this.firstChain) {
-        object.chain[object.chain.length - 1] += this.number;
+        object.chain[object.chain.length - 1] += legify(this.number);
         this.firstChain = false;
       } else {
         if (this.number % 2 === 0) {
@@ -451,10 +453,10 @@ export default {
             this.number.toString().length <
           85
         )
-          object.chain[object.chain.length - 1] += "->" + this.number;
+          object.chain[object.chain.length - 1] += "->" + legify(this.number);
         else {
           object.chain.push("");
-          object.chain[object.chain.length - 1] += this.number;
+          object.chain[object.chain.length - 1] += legify(this.number);
         }
         if (this.numberArr[0].chain.length > 6) {
           this.row = this.numberArr[0].chain.length;

--- a/src/components/lessons/palindromes/NumberTable.vue
+++ b/src/components/lessons/palindromes/NumberTable.vue
@@ -49,6 +49,7 @@
 </template>
 
 <script>
+import { legify } from "../../common/utils.js";
 export default {
   props: ["tableData", "selectedIndex"],
   watch: {
@@ -71,6 +72,7 @@ export default {
     }
   },
   methods: {
+    legify,
     handleEmitData(index) {
       this.$emit("selectData", index);
     }

--- a/src/components/lessons/palindromes/utils.js
+++ b/src/components/lessons/palindromes/utils.js
@@ -1,5 +1,7 @@
+import { legify } from "../../common/utils.js";
+
 export const MESSAGE = {
-  INPUT_PROMPT: "Enter a number to find its palindrome(1-99999999999999)",
+  INPUT_PROMPT: `Enter a number (1 to ${legify(99999999999999)})`,
   CONFIRM_PALINDROME: "The number entered is a palindrome",
   PALINDROME_FOUND: number => {
     return `Palindrome found in ${number} addition${number > 1 ? "s" : ""}`;

--- a/src/components/lessons/problem-dice/DistributionApp.vue
+++ b/src/components/lessons/problem-dice/DistributionApp.vue
@@ -66,7 +66,7 @@
 				@click="handleToggleTimer"
 			>
 				{{isStart ? (
-					timer ? "Tap here to pause" : "Tap here to resume"
+					timer ? "Pause" : "Resume"
 				)  :"Start auto" }}
 			</button>
 			<button

--- a/src/components/lessons/problem-dice/DistributionApp.vue
+++ b/src/components/lessons/problem-dice/DistributionApp.vue
@@ -38,7 +38,7 @@
 							<th></th>
 							<th>
 								<span v-if="trialNumber > 0" class="app--game-data-tried font-weight-bold">
-									{{ trialNumber }} trials
+									{{ legify(trialNumber) }} trials
 								</span>
 							</th>
 						</tr>
@@ -47,7 +47,7 @@
 							<th></th>
 							<th>
 								<span v-if="triedNumber > 0" class="app--game-data-tried font-weight-bold">
-									Trial {{ triedNumber }}
+									Trial {{ legify(triedNumber) }}
 								</span>
 							</th>
 						</tr>
@@ -96,6 +96,7 @@
 import DiffGraph from './DiffGraph.vue';
 import DemoAutoOption from './DemoAutoOption.vue';
 import { throwDice } from './utils';
+import {legify} from '../../common/utils.js';
 
 export default {
 	props: ['trialNumber'],
@@ -145,6 +146,7 @@ export default {
 		}
 	},
 	methods: {
+		legify,
 		handleNextMove() {
 			if(!this.isStart) this.isStart = true;
 			this.dice1 = throwDice();

--- a/src/components/lessons/problem-dice/Game.vue
+++ b/src/components/lessons/problem-dice/Game.vue
@@ -50,23 +50,23 @@
             style="table-layout:fixed;"
           >
             <tr>
-              <th>{{ playAWinsNumber }}</th>
-              <th>{{ playAWinsPercent + '%' }}</th>
+              <th>{{ legify(playAWinsNumber) }}</th>
+              <th>{{ playAWinsPercent.toFixed(2) + '%' }}</th>
               <th>
                 <span
                   v-if="trialNumber > 0"
                   class="app--game-data-tried font-weight-bold"
-                >{{ trialNumber }} trials</span>
+                >{{ legify(trialNumber) }} trials</span>
               </th>
             </tr>
             <tr>
-              <th>{{ playBWinsNumber }}</th>
-              <th>{{ playBWinsPercent + '%' }}</th>
+              <th>{{ legify(playBWinsNumber) }}</th>
+              <th>{{ playBWinsPercent.toFixed(2) + '%' }}</th>
               <th>
                 <span
                   v-if="triedNumber > 0"
                   class="app--game-data-tried font-weight-bold"
-                >Trial {{ triedNumber }}</span>
+                >Trial {{ legify(triedNumber) }}</span>
               </th>
             </tr>
           </table>
@@ -119,6 +119,7 @@ import DiffGraph from "./DiffGraph.vue";
 import DiceGraph from "./DiceGraph.vue";
 import DemoAutoOption from "./DemoAutoOption.vue";
 import { throwDice } from "./utils";
+import {legify} from '../../common/utils.js';
 
 export default {
   props: ["gameType", "trialNumber"], // gameType: 1 - Demonstration game, 2- Play many games
@@ -149,15 +150,11 @@ export default {
   computed: {
     playerAWinsPercent() {
       if (!this.triedNumber) return 0;
-      return Number(
-        ((this.playAWinsNumber / this.triedNumber) * 100).toFixed(2)
-      );
+      return (this.playAWinsNumber / this.triedNumber) * 100;
     },
     playerBWinsPercent() {
       if (!this.triedNumber) return 0;
-      return Number(
-        ((this.playAWinsNumber / this.triedNumber) * 100).toFixed(2)
-      );
+      return (this.playAWinsNumber / this.triedNumber) * 100;
     },
     timerInterval() {
       if (!this.trialNumber) return 50;
@@ -199,6 +196,7 @@ export default {
     }
   },
   methods: {
+    legify,
     handleTogglePlayer(index) {
       if (!this.isSet) {
         let toggledPlayer = this.playerSet[index] === 0 ? 1 : 0;

--- a/src/components/lessons/radioactivity/ManyTrialsApp.vue
+++ b/src/components/lessons/radioactivity/ManyTrialsApp.vue
@@ -45,7 +45,7 @@
 					<table class="table">
 						<tr>
 							<td class="entryDesc">Initial number of atoms:</td>
-							<td class="entryData">{{trialInputs.numAtoms}}</td>
+							<td class="entryData">{{legify(trialInputs.numAtoms)}}</td>
 						</tr>
 						<tr>
 							<td class="entryDesc">Prob of decay is 1 in {{trialInputs.probDecay}}</td>
@@ -57,7 +57,7 @@
 						</tr>
 						<tr>
 							<td class="entryDesc">Atoms left:</td>
-							<td class="entryData">{{atomLeft}}</td>
+							<td class="entryData">{{legify(atomLeft)}}</td>
 						</tr>
 						<tr>
 							<td class="entryDesc">Percentage left:</td>
@@ -73,6 +73,8 @@
 <script>
 /* eslint-disable */
 import Dice from './Dice.vue';
+import { legify } from '../../common/utils.js';
+
 import {
 	drawInitialGraph,
 	rerollAtoms,
@@ -227,6 +229,7 @@ export default {
 		}
 	},
 	methods: {
+		legify,
 		//function used to run the auto mode
 		autoMode(){
 			if (this.isAuto && !this.showStart){

--- a/src/components/lessons/radioactivity/ManyTrialsApp.vue
+++ b/src/components/lessons/radioactivity/ManyTrialsApp.vue
@@ -27,7 +27,7 @@
 							</div>
 						</div>
 						<div v-else>
-							<button type="button" class="btn btn-outline-dark" @click="reset">Tap here to reset</button>
+							<button type="button" class="btn btn-outline-dark" @click="reset">Reset</button>
 						</div>
 					</div>
 					<div class="form-check form-check-inline">

--- a/src/components/lessons/radioactivity/ManyTrialsInput.vue
+++ b/src/components/lessons/radioactivity/ManyTrialsInput.vue
@@ -2,7 +2,7 @@
 	<div>
 		<div class="app--enter-number form-group row mt-5">
 			<label for="trial-numbers" class="col-form-label col-sm-6">
-				<span style="color: darkred">Enter the number of atoms</span> (10 to 10,000):
+				<span style="color: darkred">Enter the number of atoms</span> (10 to {{legify(10000)}}):
 			</label>
 			<div class="col-sm-6">
 				<input type="number" class="form-control" v-model="numAtoms" required>
@@ -25,6 +25,7 @@
 </template>
 
 <script>
+	import { legify } from '../../common/utils.js';
 	export default {
 		data: function() {
 			return {
@@ -51,6 +52,7 @@
 			}
 		},
 		methods: {
+			legify,
 			handleAcceptTrialInputs() {
 				this.$emit('acceptTrialInputs', this.trialInputs);
 			}

--- a/src/components/lessons/same-or-different/ManyTrials.vue
+++ b/src/components/lessons/same-or-different/ManyTrials.vue
@@ -7,7 +7,7 @@
 				<form>
 					<div class="app--enter-number form-group row mt-5">
 						<label for="trial-numbers" class="col-form-label col-sm-8" style="color: darkred">
-							Enter the number of trials(1 - {{maxTrialInput}}):
+							Enter the number of trials (1 to {{legify(maxTrialInput)}}):
 						</label>
 						<div class="col-sm-4">
 							<input type="number" class="form-control" v-model="trialNumber" required>
@@ -15,7 +15,7 @@
 					</div>
 					<div class="app--enter-number form-group row mt-3">
 						<label for="numPlantsInput" class="col-sm-8 col-form-label" style="color: red">
-							Enter number of red blocks(1-{{maxBlockInput}}):
+							Enter number of red blocks (1 to {{maxBlockInput}}):
 						</label>
 						<div class="col-sm-3">
 							<input type="number"
@@ -28,7 +28,7 @@
 					</div>
 					<div class="app--enter-number form-group row mt-3">
 						<label for="numTilesInput" class="col-sm-8 col-form-label" style="color: blue">
-							Enter number of blue blocks(1-{{maxBlockInput}}):
+							Enter number of blue blocks (1 to {{maxBlockInput}}):
 						</label>
 						<div class="col-sm-3">
 							<input type="number"
@@ -65,9 +65,9 @@
 							</tr>
 							<tr>
 								<td><h5 class="statLabel">Number of wins:</h5></td>
-								<td><h4 class="stat">{{numSame}}</h4></td>
-								<td><h4 class="stat">{{numDiff}}</h4></td>
-								<td><h4 class="stat">{{numTotal}}</h4></td>
+								<td><h4 class="stat">{{legify(numSame)}}</h4></td>
+								<td><h4 class="stat">{{legify(numDiff)}}</h4></td>
+								<td><h4 class="stat">{{legify(numTotal)}}</h4></td>
 							</tr>
 							<tr>
 								<td><h4 class="statLabel"></h4></td>
@@ -77,7 +77,7 @@
 						</table>
 					</div>
 					<div class="pb-5">
-						<h5 id="trialNum">{{trialNumber}} trials</h5>
+						<h5 id="trialNum">{{legify(trialNumber)}} trials</h5>
 					</div>
 
 					<div class="app--action mt-4">
@@ -115,6 +115,7 @@ import {
 	drawNextTwoBlocks,
 	drawNextCanvas
 } from './utils';
+import { legify } from '../../common/utils.js';
 
 export default {
 	data: function() {
@@ -190,13 +191,13 @@ export default {
 		statSame: function(){
 			if (this.numTotal == 0)
 				return 0 + '%';
-			var res = parseFloat(((this.numSame/this.numTotal)*100).toFixed(2));
+			var res = ((this.numSame/this.numTotal)*100).toFixed(2);
 			return res + '%';
 		},
 		statDiff: function(){
 			if (this.numTotal == 0)
 				return 0 + '%';
-			var res = parseFloat(((this.numDiff/this.numTotal)*100).toFixed(2));
+			var res = ((this.numDiff/this.numTotal)*100).toFixed(2);
 			return  res + '%';
 		}
 	},
@@ -215,6 +216,7 @@ export default {
 		}
 	},
 	methods: {
+		legify,
 		//this function reset all the statistics
 		resetTrial(){
 			this.numDiff = 0;

--- a/src/components/lessons/same-or-different/PlayAGame.vue
+++ b/src/components/lessons/same-or-different/PlayAGame.vue
@@ -7,7 +7,7 @@
 				<form>
 					<div class="app--enter-number form-group row mt-3">
 						<label for="numPlantsInput" class="col-sm-9 col-form-label" style="color: red">
-							Enter number of red blocks(1-{{maxBlockInput}}):
+							Enter number of red blocks (1 to {{maxBlockInput}}):
 						</label>
 						<div class="col-sm-3">
 							<input type="number"
@@ -20,7 +20,7 @@
 					</div>
 					<div class="app--enter-number form-group row mt-3">
 						<label for="numTilesInput" class="col-sm-9 col-form-label" style="color: blue">
-							Enter number of blue blocks(1-{{maxBlockInput}}):
+							Enter number of blue blocks (1 to {{maxBlockInput}}):
 						</label>
 						<div class="col-sm-3">
 							<input type="number"

--- a/src/components/lessons/snakes-and-ladders/LandingChance.vue
+++ b/src/components/lessons/snakes-and-ladders/LandingChance.vue
@@ -14,11 +14,11 @@
         </div>
         <div class="col-md-4">
           <div style="position: sticky; top: 0;">
-            <h5 class="text-center">Play {{ trialNumber }} games</h5>
+            <h5 class="text-center">Play {{ legify(trialNumber) }} games</h5>
             <table class="table table-bordered" style="table-layout: fixed">
               <tr>
                 <th>Game</th>
-                <td>{{ playedGames }}</td>
+                <td>{{ legify(playedGames) }}</td>
               </tr>
               <tr>
                 <th>Average</th>
@@ -26,7 +26,7 @@
               </tr>
               <tr>
                 <th>Total moves</th>
-                <td>{{ separateNumber(totalMoves) }}</td>
+                <td>{{ legify(totalMoves) }}</td>
               </tr>
             </table>
             <div class="text-center mb-2">
@@ -59,10 +59,10 @@ import DemoAutoOption from "../../common/DemoAutoOption.vue";
 import ChanceBoard from "./ChanceBoard.vue";
 
 import {
-  separateNumber,
+  legify,
   calculateTimerInterval,
   pickNumber
-} from "../../common/utils";
+} from "../../common/utils.js";
 export default {
   props: ["boardSettings"],
   components: {
@@ -77,8 +77,7 @@ export default {
       playedGames: 0,
       totalMoves: 0,
       timer: null,
-      gamesChanceData: {},
-      separateNumber
+      gamesChanceData: {}
     };
   },
   computed: {
@@ -86,7 +85,7 @@ export default {
       if (this.playedGames === 0) {
         return null;
       }
-      return Number((this.totalMoves / this.playedGames).toFixed(2));
+      return (this.totalMoves / this.playedGames).toFixed(2);
     },
     timerInterval() {
       return calculateTimerInterval(this.trialNumber);
@@ -110,6 +109,7 @@ export default {
     }
   },
   methods: {
+    legify,
     throwDice() {
       return pickNumber(1, 6);
     },

--- a/src/components/lessons/snakes-and-ladders/PlayAGame.vue
+++ b/src/components/lessons/snakes-and-ladders/PlayAGame.vue
@@ -95,7 +95,7 @@
                 class="btn btn-outline-dark"
                 v-if="(status===3 || status ===4 || status === 2) && demoAutoOption==='1' && timer"
                 @click="handleToggleTimer"
-              >Tap here to pause</button>
+              >Pause</button>
               <button class="btn btn-outline-dark" v-if="status===5" @click="handleReset">Reset</button>
             </div>
             <div class="text-center mt-2" v-if="status>=2">

--- a/src/components/lessons/snakes-and-ladders/PlayManyGamesApp.vue
+++ b/src/components/lessons/snakes-and-ladders/PlayManyGamesApp.vue
@@ -6,11 +6,11 @@
       </div>
       <div class="col-md-4">
         <div style="position: sticky; top:0;">
-          <h5 class="text-center">Play {{ trialNumber}} games</h5>
+          <h5 class="text-center">Play {{ legify(trialNumber)}} games</h5>
           <table class="table table-bordered" style="table-layout: fixed">
             <tr>
               <th>Game</th>
-              <td>{{ playedGames }}</td>
+              <td>{{ legify(playedGames) }}</td>
             </tr>
             <tr>
               <th>Average</th>
@@ -55,7 +55,7 @@
 <script>
 import Board from "./Board.vue";
 import DemoAutoOption from "../../common/DemoAutoOption.vue";
-import { pickNumber, calculateTimerInterval } from "../../common/utils";
+import { pickNumber, calculateTimerInterval, legify } from "../../common/utils.js";
 export default {
   props: ["boardSettings", "trialNumber"],
   components: {
@@ -98,10 +98,11 @@ export default {
       if (this.playedGames === 0) {
         return 0;
       }
-      return Number((this.sum / this.playedGames).toFixed(2));
+      return (this.sum / this.playedGames).toFixed(2);
     }
   },
   methods: {
+    legify,
     throwDice() {
       return pickNumber(1, 6);
     },

--- a/src/components/lessons/sporting-finals-AFL/PlayManyFinals.vue
+++ b/src/components/lessons/sporting-finals-AFL/PlayManyFinals.vue
@@ -13,7 +13,7 @@
                                 <h5 class="text-success" >
                                     Enter the number of trials:<input v-model="numberOfTiles" placeholder="number" class="input-group" v-bind:disabled="disableInput">
                                 </h5>
-                                    <h6 class="text-success">Range is 1 to 16000</h6>
+                                    <h6 class="text-success">Range is 1 to {{legify(16000)}}</h6>
                                     <div v-if="appear">
                                         <button class="btn btn-outline-success" style="margin-right: 30px" @click="oneTrial" v-if="playDemoGame">Play Demo</button>
 
@@ -160,10 +160,10 @@
                                     </td>
                                 </tr>
                                 <tr v-if="appear">
-                                    <td class="originalTB">{{numberOfTiles}} trials</td>
+                                    <td class="originalTB">{{legify(numberOfTiles)}} trials</td>
 
                                     <td><div class="changedTwo">Total</div></td>
-                                    <td><div class="changedTB">{{totalCount}}</div></td>
+                                    <td><div class="changedTB">{{legify(totalCount)}}</div></td>
                                 </tr>
 
                                 </tbody>
@@ -183,6 +183,7 @@
 <script>
     import global from "./EnterTeams"
     import pickedGlobal from "./PercentageAdvantage"
+    import { legify } from '../../common/utils.js';
     export default {
         name: "PlayManyFinals",
         data:function () {
@@ -191,7 +192,7 @@
                 disappear: true,
                 numberOfTiles:"",
                 alert : false,
-                alertWords:"Please enter the number of trials(1 to 16000)",
+                alertWords:`Please enter the number of trials (1 to ${legify(16000)})`,
                 playAutoGame:true,
                 playDemoGame : true,
 
@@ -262,6 +263,7 @@
 
         },
         methods:{
+            legify,
             submitTrials: function () {
                 if(isNaN(this.numberOfTiles)==true){
                     this.alert = true
@@ -309,7 +311,7 @@
                 this.disappear= true;
                 this.numberOfTiles = "";
                 this.alert = false;
-                this.alertWords= "Please enter the number of trials(1 to 16000)";
+                this.alertWords= `Please enter the number of trials (1 to ${legify(16000)})`;
                 this.playAutoGame= true;
                 this.playDemoGame = true;
                 this.team1= "";

--- a/src/components/lessons/sporting-finals-NRL/PlayManyFinals.vue
+++ b/src/components/lessons/sporting-finals-NRL/PlayManyFinals.vue
@@ -13,7 +13,7 @@
                                     <h5 class="text-success" >
                                         Enter the number of trials:<input v-model="numberOfTiles" placeholder="number" class="input-group" v-bind:disabled="disableInput">
                                     </h5>
-                                    <h6 class="text-success">Range is 1 to 16000</h6>
+                                    <h6 class="text-success">Range is 1 to {{legify(16000)}}</h6>
                                     <div v-if="appear">
                                         <button class="btn btn-outline-success" style="margin-right: 30px" @click="oneTrial" v-if="playDemoGame">Play Demo</button>
 
@@ -160,10 +160,10 @@
                                     </td>
                                 </tr>
                                 <tr v-if="appear">
-                                    <td class="originalTB">{{numberOfTiles}} trials</td>
+                                    <td class="originalTB">{{legify(numberOfTiles)}} trials</td>
 
                                     <td><div class="changedTwo">Total</div></td>
-                                    <td><div class="changedTB">{{totalCount}}</div></td>
+                                    <td><div class="changedTB">{{legify(totalCount)}}</div></td>
                                 </tr>
 
                                 </tbody>
@@ -181,6 +181,7 @@
 </template>
 
 <script>
+    import { legify } from '../../common/utils.js';
     import global from "./EnterTeams"
     import pickedGlobal from "./PercentageAdvantage"
     export default {
@@ -191,7 +192,7 @@
                 disappear: true,
                 numberOfTiles:"",
                 alert : false,
-                alertWords:"Please enter the number of trials(1 to 16000)",
+                alertWords:`Please enter the number of trials (1 to ${legify(16000)})`,
                 playAutoGame:true,
                 playDemoGame : true,
 
@@ -262,6 +263,7 @@
 
         },
         methods:{
+            legify,
             submitTrials: function () {
                 if(isNaN(this.numberOfTiles)==true){
                     this.alert = true
@@ -309,7 +311,7 @@
                 this.disappear= true;
                 this.numberOfTiles = "";
                 this.alert = false;
-                this.alertWords= "Please enter the number of trials(1 to 16000)";
+                this.alertWords= `Please enter the number of trials (1 to ${legify(16000)})`;
                 this.playAutoGame= true;
                 this.playDemoGame = true;
                 this.team1= "";

--- a/src/components/lessons/walk-the-plank/ManyGamesApp.vue
+++ b/src/components/lessons/walk-the-plank/ManyGamesApp.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container mt-3 mb-5">
-    <h3 class="lesson-subheading">Many games fast: change the plank length - {{ gameSetting.trialNumber}} games</h3>
+    <h3 class="lesson-subheading">Many games fast: change the plank length - {{ legify(gameSetting.trialNumber)}} games</h3>
     <hr class="subheading-separator">
     <app-game-table-max
       :plankLength="plankLength"
@@ -44,7 +44,7 @@ import GameTableMax from "./GameTableMax.vue";
 import DemoAutoOption from "../../common/DemoAutoOption.vue";
 import GameFrequencyGraph from "./GameFrequencyGraph.vue";
 import Plank from "./Plank";
-import { calculateTimerInterval } from "../../common/utils";
+import { calculateTimerInterval, legify } from "../../common/utils.js";
 
 export default {
   components: {
@@ -83,7 +83,7 @@ export default {
       if (this.numberOfGames <= 1) {
         return 0;
       }
-      return Number((this.totalTurns / (this.numberOfGames - 1)).toFixed(2));
+      return (this.totalTurns / (this.numberOfGames - 1)).toFixed(2);
     },
     timerInterval() {
       let { trialNumber } = this.gameSetting;
@@ -119,6 +119,7 @@ export default {
     }
   },
   methods: {
+    legify,
     handlePlayOneGame() {
       if (!this.isStart) this.isStart = true;
       this.turns = this.plank.playOneGameAndGetTurns();

--- a/src/components/lessons/walk-the-plank/SetGame.vue
+++ b/src/components/lessons/walk-the-plank/SetGame.vue
@@ -2,7 +2,7 @@
 	<div>
 		<div class="app--enter-number form-group row mt-5">
 			<label for="trial-numbers" class="col-form-label col-sm-6">
-				Enter the number of trials (1 to 10000):
+				Enter the number of trials (1 to {{legify(10000)}}):
 			</label>
 			<div class="col-sm-6">
 				<input type="number" class="form-control" v-model="trialNumber" required>
@@ -26,6 +26,7 @@
 </template>
 
 <script>
+	import { legify } from '../../common/utils.js';
 	export default {
 		data: function() {
 			return {
@@ -52,6 +53,7 @@
 			}
 		},
 		methods: {
+			legify,
 			handleSetGame() {
 				this.$emit(
 					'acceptGameSetting',

--- a/src/components/lessons/walk-the-plank/SeveralGames.vue
+++ b/src/components/lessons/walk-the-plank/SeveralGames.vue
@@ -91,8 +91,8 @@
     </div>
     <div class="app--action text-center" v-if="demoAutoOption=='1'">
       <button class="btn btn-outline-success" @click="handleToggleTimer">
-        {{ !isStart ? "Tap here to begin" :
-        ( timer ? "Tap here to pause" : "Tap here to resume") }}
+        {{ !isStart ? "Start" :
+        ( timer ? "Pause" : "Resume") }}
       </button>
     </div>
     <div class="text-center mt-1 mb-3">

--- a/src/components/lessons/whats-my-rule/WhatsMyRule.vue
+++ b/src/components/lessons/whats-my-rule/WhatsMyRule.vue
@@ -153,7 +153,7 @@ import {
   generateFormation,
   generateRuleArray,
   generateWords,
-  converStr
+  convertStr
 } from "./utils";
 export default {
   data: function() {
@@ -207,7 +207,7 @@ export default {
       }
 
       this.ruleFormationCheck =
-        converStr(this.ruleFormationInput) === converStr(this.ruleFormation);
+        convertStr(this.ruleFormationInput) === convertStr(this.ruleFormation);
     }
   }
 };

--- a/src/components/lessons/whats-my-rule/utils.js
+++ b/src/components/lessons/whats-my-rule/utils.js
@@ -115,14 +115,14 @@ export const generateWords = rule => {
   }
   return `To find the Out number,
 								multiply the In number by ${rule.multiply},
-								then ${operation} ${Math.abs(rule.addition)} `;
+								then ${operation} ${Math.abs(rule.addition)}.`;
 };
 
 /**
  * Remove the blanks within a string, replace '1x' with 'x' and convert to lower string
  * @param {string} str
  */
-export const converStr = str => {
+export const convertStr = str => {
   let strNoBlank = "";
   for (let i = 0; i < str.length; i++) {
     if (str[i] !== " ") {

--- a/src/components/lessons/win-at-the-fair/RunTrialsApp.vue
+++ b/src/components/lessons/win-at-the-fair/RunTrialsApp.vue
@@ -4,7 +4,7 @@
       <table class="table table-bordered">
         <thead>
           <tr class="text-center">
-            <th colspan="3">{{ trialNumber }} trials</th>
+            <th colspan="3">{{ legify(trialNumber) }} trials</th>
           </tr>
         </thead>
         <tbody class="text-center">
@@ -18,10 +18,10 @@
               {{ item.prize % 1 > 0 ? item.prize.toFixed(2) : item.prize }}
             </td>
             <td>
-              <span v-if="status > 0">{{ item.winners }}</span>
+              <span v-if="status > 0">{{ legify(item.winners) }}</span>
             </td>
             <td>
-              <span v-if="status > 0">{{ (item.winners * item.prize).toFixed(2) }}</span>
+              <span v-if="status > 0">{{ legify((item.winners * item.prize), 2) }}</span>
             </td>
           </tr>
         </tbody>
@@ -29,16 +29,16 @@
           <tr>
             <th>Total</th>
             <td>
-              <span v-if="status > 0">{{ triedNumber }}</span>
+              <span v-if="status > 0">{{ legify(triedNumber) }}</span>
             </td>
             <td>
-              <span v-if="status > 0">{{ totalPayout.toFixed(2) }}</span>
+              <span v-if="status > 0">{{ '$' + legify(totalPayout, 2) }}</span>
             </td>
           </tr>
           <tr>
             <th>Average payout</th>
             <td colspan="2">
-              <span v-if="status > 0">{{ (totalPayout / triedNumber).toFixed(2) }}</span>
+              <span v-if="status > 0">{{ '$' + (totalPayout / triedNumber).toFixed(2) }}</span>
             </td>
           </tr>
         </tfoot>
@@ -76,7 +76,7 @@
 import RuleMap from "./RuleMap.vue";
 import DemoAutoOption from "../../common/DemoAutoOption.vue";
 import { createMap, convertValuesId } from "./utils";
-import { pickNumber, calculateTimerInterval } from "../../common/utils";
+import { pickNumber, calculateTimerInterval, legify } from "../../common/utils.js";
 
 export default {
   props: ["rules", "values", "trialNumber"],
@@ -121,6 +121,7 @@ export default {
     }
   },
   methods: {
+    legify,
     initTrialData() {
       let trialData = [];
       for (let i = 0; i < this.values.length; i++) {


### PR DESCRIPTION
Makes large numbers readable by inserting "thin spaces" and fixes decimals in trials so they don't jitter. Various other minor fixes.

Detail:
I made a function "legify()" to help make large numbers easier to read (more legible). It is similar to the existing "separateNumber()" function, but adds "thin spaces" in the modern maths textbook style instead of commas. It also adds spaces to decimals in the opposite direction, and takes an optional second argument for fixed number of decimals to help with readability on trials. I have used this function to improve the readability of various large numbers across the software.